### PR TITLE
ci: fix doubling of `rc` version identifier

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
             # Use git describe tags to identify the number of commits the branch
             # is ahead of the most recent non-release-candidate tag, which is
             # part of the rc.<commits> value.
-            RELEASE_VERSION=$MAIN_RELEASE_VERSION-rc.$(node -e "console.log('$(git describe --tags --exclude *rc*)'.split('-')[1])")
+            RELEASE_VERSION=$MAIN_RELEASE_VERSION-rc.$(node -e "console.log('$(git describe --tags --exclude rc*)'.split('-')[1])")
 
             # release-please only ignores releases that have a form like [A-Z0-9]<version>, so prefixing with rc<version>
             RELEASE_NAME="rc$RELEASE_VERSION"


### PR DESCRIPTION
When an RC is published on top of an existing RC, the `rc` identifier doubles. Example from [`@supabase/auth-js`](https://www.npmjs.com/package/@supabase/auth-js/v/2.64.3-rc.rc.rc.3) which uses pretty much the same Github Actions workflow file.

The fix is to change the `git describe --tags --exclude` to a value that actually excludes [tags that start with `rc`](https://github.com/supabase/ssr/releases/tag/rc0.4.0-rc.2).