### PR TITLE
fix: allow use of `createBrowserClient` without `window` present

### DIFF
--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -155,9 +155,17 @@ export function createStorageFromOptions(
       "@supabase/ssr: createServerClient must be initialized with cookie options that specify getAll and setAll functions (deprecated, not recommended: alternatively use get, set and remove)",
     );
   } else {
-    throw new Error(
-      "@supabase/ssr: createBrowserClient in non-browser runtimes must be initialized with cookie options that specify getAll and setAll functions (deprecated: alternatively use get, set and remove)",
-    );
+    // getting cookies when there's no window but we're in browser mode can be OK, because the developer probably is not using auth functions
+    getAll = () => {
+      return [];
+    };
+
+    // this is NOT OK because the developer is using auth functions that require setting some state, so that must error out
+    setAll = () => {
+      throw new Error(
+        "@supabase/ssr: createBrowserClient in non-browser runtimes (including Next.js pre-rendering mode) was not initialized cookie options that specify getAll and setAll functions (deprecated: alternatively use get, set and remove), but they were needed",
+      );
+    };
   }
 
   if (!isServerClient) {


### PR DESCRIPTION
Allows calling `createBrowserClient` without throwing an error when not in a browser context (i.e. `window` is missing).

This is especially useful when using in Next.js Pre-Rendering mode where the client's non-`auth` namespaces could be useful, such as to load public data from PostgREST.

If however the `auth` namespace is used, the `setAll` handler function will throw an error indicating to the user that they're doing something wrong. This shouldn't come up in Pre-Rendering mode ever.

See: https://github.com/orgs/supabase/discussions/27037#discussioncomment-9852948