### PR TITLE
fix: PASSWORD_RECOVERY event missing

### DIFF
--- a/src/createServerClient.ts
+++ b/src/createServerClient.ts
@@ -193,6 +193,7 @@ export function createServerClient<
       (event === "SIGNED_IN" ||
         event === "TOKEN_REFRESHED" ||
         event === "USER_UPDATED" ||
+        event === "PASSWORD_RECOVERY" ||
         event === "SIGNED_OUT")
     ) {
       await applyServerStorage(


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When resetting a user's password with an email template which has a URL defining the `type` value of `recovery` and using `verifyOtp` in dev code to process the `token_hash` and `type`, the SSR server client's `onAuthStateChange` function does not recognize the `PASSWORD_RECOVERY` event that `verifyOtp` uses in this case. Therefore the new session does not get saved to storage and the user is not logged in, in order to reset their password.

## What is the new behavior?

User is logged in.

## Additional context

Fixes #21 
