### PR TITLE
fix: set cookies when mfa challenge is verified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,15 @@
 
 ## [0.4.0](https://github.com/supabase/ssr/compare/v0.3.0...v0.4.0) (2024-06-24)
 
-
 ### Features
 
-* full rewrite using `getAll` and `setAll` cookie methods ([#1](https://github.com/supabase/ssr/issues/1)) ([b6ae192](https://github.com/supabase/ssr/commit/b6ae192aeb37ac6948637955cf1d3d6179b90065))
-
+- full rewrite using `getAll` and `setAll` cookie methods ([#1](https://github.com/supabase/ssr/issues/1)) ([b6ae192](https://github.com/supabase/ssr/commit/b6ae192aeb37ac6948637955cf1d3d6179b90065))
 
 ### Bug Fixes
 
-* allow use of `createBrowserClient` without `window` present ([#20](https://github.com/supabase/ssr/issues/20)) ([27d868d](https://github.com/supabase/ssr/commit/27d868d530925805fe2f3577ae716ece40dd3ab6))
-* deprecate `parse`, `serialize` exports for more useful functions ([#14](https://github.com/supabase/ssr/issues/14)) ([0b5f881](https://github.com/supabase/ssr/commit/0b5f881e90b7836f2b98b733aac1cc9f916286cb))
-* fix `createBrowserClient` deprecation tsdoc ([#17](https://github.com/supabase/ssr/issues/17)) ([1df70ad](https://github.com/supabase/ssr/commit/1df70ad51e65caab46cbc00342dbb42f6d498c32))
+- allow use of `createBrowserClient` without `window` present ([#20](https://github.com/supabase/ssr/issues/20)) ([27d868d](https://github.com/supabase/ssr/commit/27d868d530925805fe2f3577ae716ece40dd3ab6))
+- deprecate `parse`, `serialize` exports for more useful functions ([#14](https://github.com/supabase/ssr/issues/14)) ([0b5f881](https://github.com/supabase/ssr/commit/0b5f881e90b7836f2b98b733aac1cc9f916286cb))
+- fix `createBrowserClient` deprecation tsdoc ([#17](https://github.com/supabase/ssr/issues/17)) ([1df70ad](https://github.com/supabase/ssr/commit/1df70ad51e65caab46cbc00342dbb42f6d498c32))
 
 ## 0.3.0
 

--- a/src/createServerClient.ts
+++ b/src/createServerClient.ts
@@ -193,7 +193,8 @@ export function createServerClient<
       (event === "SIGNED_IN" ||
         event === "TOKEN_REFRESHED" ||
         event === "USER_UPDATED" ||
-        event === "SIGNED_OUT")
+        event === "SIGNED_OUT" ||
+        event === "MFA_CHALLENGE_VERIFIED")
     ) {
       await applyServerStorage(
         { getAll, setAll, setItems, removedItems },

--- a/src/createServerClient.ts
+++ b/src/createServerClient.ts
@@ -32,7 +32,7 @@ export function createServerClient<
     : string & keyof Database,
   Schema extends GenericSchema = Database[SchemaName] extends GenericSchema
     ? Database[SchemaName]
-    : any
+    : any,
 >(
   supabaseUrl: string,
   supabaseKey: string,
@@ -40,7 +40,7 @@ export function createServerClient<
     cookieOptions?: CookieOptionsWithName;
     cookies: CookieMethodsServerDeprecated;
     cookieEncoding?: "raw" | "base64url";
-  }
+  },
 ): SupabaseClient<Database, SchemaName, Schema>;
 
 /**
@@ -111,7 +111,7 @@ export function createServerClient<
     : string & keyof Database,
   Schema extends GenericSchema = Database[SchemaName] extends GenericSchema
     ? Database[SchemaName]
-    : any
+    : any,
 >(
   supabaseUrl: string,
   supabaseKey: string,
@@ -119,7 +119,7 @@ export function createServerClient<
     cookieOptions?: CookieOptionsWithName;
     cookies: CookieMethodsServer;
     cookieEncoding?: "raw" | "base64url";
-  }
+  },
 ): SupabaseClient<Database, SchemaName, Schema>;
 
 export function createServerClient<
@@ -129,7 +129,7 @@ export function createServerClient<
     : string & keyof Database,
   Schema extends GenericSchema = Database[SchemaName] extends GenericSchema
     ? Database[SchemaName]
-    : any
+    : any,
 >(
   supabaseUrl: string,
   supabaseKey: string,
@@ -137,11 +137,11 @@ export function createServerClient<
     cookieOptions?: CookieOptionsWithName;
     cookies: CookieMethodsServer | CookieMethodsServerDeprecated;
     cookieEncoding?: "raw" | "base64url";
-  }
+  },
 ): SupabaseClient<Database, SchemaName, Schema> {
   if (!supabaseUrl || !supabaseKey) {
     throw new Error(
-      `Your project's URL and Key are required to create a Supabase client!\n\nCheck your Supabase project's API settings to find these values\n\nhttps://supabase.com/dashboard/project/_/settings/api`
+      `Your project's URL and Key are required to create a Supabase client!\n\nCheck your Supabase project's API settings to find these values\n\nhttps://supabase.com/dashboard/project/_/settings/api`,
     );
   }
 
@@ -151,7 +151,7 @@ export function createServerClient<
         ...options,
         cookieEncoding: options?.cookieEncoding ?? "base64url",
       },
-      true
+      true,
     );
 
   const client = createClient<Database, SchemaName, Schema>(
@@ -177,7 +177,7 @@ export function createServerClient<
         persistSession: true,
         storage,
       },
-    }
+    },
   );
 
   client.auth.onAuthStateChange(async (event) => {
@@ -201,7 +201,7 @@ export function createServerClient<
         {
           cookieOptions: options?.cookieOptions ?? null,
           cookieEncoding: options?.cookieEncoding ?? "base64url",
-        }
+        },
       );
     }
   });

--- a/src/createServerClient.ts
+++ b/src/createServerClient.ts
@@ -32,7 +32,7 @@ export function createServerClient<
     : string & keyof Database,
   Schema extends GenericSchema = Database[SchemaName] extends GenericSchema
     ? Database[SchemaName]
-    : any,
+    : any
 >(
   supabaseUrl: string,
   supabaseKey: string,
@@ -40,7 +40,7 @@ export function createServerClient<
     cookieOptions?: CookieOptionsWithName;
     cookies: CookieMethodsServerDeprecated;
     cookieEncoding?: "raw" | "base64url";
-  },
+  }
 ): SupabaseClient<Database, SchemaName, Schema>;
 
 /**
@@ -111,7 +111,7 @@ export function createServerClient<
     : string & keyof Database,
   Schema extends GenericSchema = Database[SchemaName] extends GenericSchema
     ? Database[SchemaName]
-    : any,
+    : any
 >(
   supabaseUrl: string,
   supabaseKey: string,
@@ -119,7 +119,7 @@ export function createServerClient<
     cookieOptions?: CookieOptionsWithName;
     cookies: CookieMethodsServer;
     cookieEncoding?: "raw" | "base64url";
-  },
+  }
 ): SupabaseClient<Database, SchemaName, Schema>;
 
 export function createServerClient<
@@ -129,7 +129,7 @@ export function createServerClient<
     : string & keyof Database,
   Schema extends GenericSchema = Database[SchemaName] extends GenericSchema
     ? Database[SchemaName]
-    : any,
+    : any
 >(
   supabaseUrl: string,
   supabaseKey: string,
@@ -137,11 +137,11 @@ export function createServerClient<
     cookieOptions?: CookieOptionsWithName;
     cookies: CookieMethodsServer | CookieMethodsServerDeprecated;
     cookieEncoding?: "raw" | "base64url";
-  },
+  }
 ): SupabaseClient<Database, SchemaName, Schema> {
   if (!supabaseUrl || !supabaseKey) {
     throw new Error(
-      `Your project's URL and Key are required to create a Supabase client!\n\nCheck your Supabase project's API settings to find these values\n\nhttps://supabase.com/dashboard/project/_/settings/api`,
+      `Your project's URL and Key are required to create a Supabase client!\n\nCheck your Supabase project's API settings to find these values\n\nhttps://supabase.com/dashboard/project/_/settings/api`
     );
   }
 
@@ -151,7 +151,7 @@ export function createServerClient<
         ...options,
         cookieEncoding: options?.cookieEncoding ?? "base64url",
       },
-      true,
+      true
     );
 
   const client = createClient<Database, SchemaName, Schema>(
@@ -177,7 +177,7 @@ export function createServerClient<
         persistSession: true,
         storage,
       },
-    },
+    }
   );
 
   client.auth.onAuthStateChange(async (event) => {
@@ -201,7 +201,7 @@ export function createServerClient<
         {
           cookieOptions: options?.cookieOptions ?? null,
           cookieEncoding: options?.cookieEncoding ?? "base64url",
-        },
+        }
       );
     }
   });


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently, create server client doesn't seem to set cookies when MFA Challenge is verified