### PR TITLE
fix: set cookies for password recovery event

### DIFF
--- a/src/createServerClient.ts
+++ b/src/createServerClient.ts
@@ -193,6 +193,7 @@ export function createServerClient<
       (event === "SIGNED_IN" ||
         event === "TOKEN_REFRESHED" ||
         event === "USER_UPDATED" ||
+        event === "PASSWORD_RECOVERY" ||
         event === "SIGNED_OUT" ||
         event === "MFA_CHALLENGE_VERIFIED")
     ) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When resetting a user's password with an email template which has a URL defining the `type` value as `recovery`, and using the `verifyOtp` method to process the token_hash and type, the SSR server client's `onAuthStateChange` function does not recognize the `PASSWORD_RECOVERY` event that verifyOtp fires. This prevents the code [here](https://github.com/supabase/ssr/blob/main/src/createServerClient.ts#L199-L205) from running; resulting in the new session not being saved to cookies, and the user is not considered logged in.

Fixes #21

## What is the new behavior?

User is logged in.

## Additional context

Replaces PR #24
