### PR TITLE
fix: max cookie maxage is 400 days

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -4,5 +4,5 @@ export const DEFAULT_COOKIE_OPTIONS: CookieOptions = {
   path: "/",
   sameSite: "lax",
   httpOnly: false,
-  maxAge: 60 * 60 * 24 * 365 * 1000,
+  maxAge: 60 * 60 * 24 * 400,
 };


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Cookies are currently being set to a Max-Age of 1000 years, instead of 365 days. Per [this RFC](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-13#section-4.1.2.2), 400 days is the maximum age that can be set for a cookie.

## What is the new behavior?

Cookie Max-Age is set to 400 days.

## Additional context

I first brought up this PR on the old auth-helpers repo: https://github.com/supabase/auth-helpers/pull/776

As of Chrome 104, this 400 day limit is enforced and any Max-Age > 400 days will be forced down to 400 days.

This is breaking my usage with Hono (see https://github.com/honojs/hono/issues/2762) and Hono does not seem motivated to change their stance on this RFC from the web server side of things.