### PR TITLE
fix: remove optional dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,9 +22,6 @@
         "typescript-eslint": "^7.10.0",
         "vitest": "^1.6.0"
       },
-      "optionalDependencies": {
-        "@rollup/rollup-linux-x64-gnu": "^4.9.5"
-      },
       "peerDependencies": {
         "@supabase/supabase-js": "^2.43.4"
       }
@@ -296,6 +293,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"

--- a/package.json
+++ b/package.json
@@ -45,9 +45,6 @@
   "peerDependencies": {
     "@supabase/supabase-js": "^2.43.4"
   },
-  "optionalDependencies": {
-    "@rollup/rollup-linux-x64-gnu": "^4.9.5"
-  },
   "dependencies": {
     "cookie": "^0.6.0"
   }


### PR DESCRIPTION
## What kind of change does this PR introduce?

This is causing an issue for a user when deploying to vercel as it's trying to install this optional dependency. However it doesn't look like this optional dependency is being used anywhere in this project.

## What is the current behavior?

Optional dependency is not being used.

## What is the new behavior?

Remove optional dependency.

## Additional context

Add any other context or screenshots.
