### PR TITLE
ci: remove CHANGELOG.md from prettier check

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+CHANGELOG.md


### PR DESCRIPTION
Since `CHANGELOG.md` is maintained by Release Please, ignoring prettier on it.