### PR TITLE
fix: set `max-age` default cookie option to 400 days

### DIFF
--- a/src/__snapshots__/createServerClient.spec.ts.snap
+++ b/src/__snapshots__/createServerClient.spec.ts.snap
@@ -34,7 +34,7 @@ exports[`createServerClient > use cases > should refresh session correctly as ty
     "name": "custom-storage-key.0",
     "options": {
       "httpOnly": false,
-      "maxAge": 31536000000,
+      "maxAge": 34560000,
       "path": "/",
       "sameSite": "lax",
     },
@@ -44,7 +44,7 @@ exports[`createServerClient > use cases > should refresh session correctly as ty
     "name": "custom-storage-key.1",
     "options": {
       "httpOnly": false,
-      "maxAge": 31536000000,
+      "maxAge": 34560000,
       "path": "/",
       "sameSite": "lax",
     },
@@ -75,7 +75,7 @@ exports[`createServerClient > use cases > should refresh session correctly as ty
     "name": "sb-project-ref-auth-token.0",
     "options": {
       "httpOnly": false,
-      "maxAge": 31536000000,
+      "maxAge": 34560000,
       "path": "/",
       "sameSite": "lax",
     },
@@ -85,7 +85,7 @@ exports[`createServerClient > use cases > should refresh session correctly as ty
     "name": "sb-project-ref-auth-token.1",
     "options": {
       "httpOnly": false,
-      "maxAge": 31536000000,
+      "maxAge": 34560000,
       "path": "/",
       "sameSite": "lax",
     },
@@ -100,7 +100,7 @@ exports[`createServerClient > use cases > should set PKCE code verifier correctl
     "name": "custom-storage-key-code-verifier",
     "options": {
       "httpOnly": false,
-      "maxAge": 31536000000,
+      "maxAge": 34560000,
       "path": "/",
       "sameSite": "lax",
     },
@@ -115,7 +115,7 @@ exports[`createServerClient > use cases > should set PKCE code verifier correctl
     "name": "sb-project-ref-auth-token-code-verifier",
     "options": {
       "httpOnly": false,
-      "maxAge": 31536000000,
+      "maxAge": 34560000,
       "path": "/",
       "sameSite": "lax",
     },
@@ -140,7 +140,7 @@ exports[`createServerClient > use cases > should set exchange PKCE code for sess
     "name": "custom-storage-key.0",
     "options": {
       "httpOnly": false,
-      "maxAge": 31536000000,
+      "maxAge": 34560000,
       "path": "/",
       "sameSite": "lax",
     },
@@ -150,7 +150,7 @@ exports[`createServerClient > use cases > should set exchange PKCE code for sess
     "name": "custom-storage-key.1",
     "options": {
       "httpOnly": false,
-      "maxAge": 31536000000,
+      "maxAge": 34560000,
       "path": "/",
       "sameSite": "lax",
     },
@@ -195,7 +195,7 @@ exports[`createServerClient > use cases > should set exchange PKCE code for sess
     "name": "sb-project-ref-auth-token.0",
     "options": {
       "httpOnly": false,
-      "maxAge": 31536000000,
+      "maxAge": 34560000,
       "path": "/",
       "sameSite": "lax",
     },
@@ -205,7 +205,7 @@ exports[`createServerClient > use cases > should set exchange PKCE code for sess
     "name": "sb-project-ref-auth-token.1",
     "options": {
       "httpOnly": false,
-      "maxAge": 31536000000,
+      "maxAge": 34560000,
       "path": "/",
       "sameSite": "lax",
     },

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -4,5 +4,7 @@ export const DEFAULT_COOKIE_OPTIONS: CookieOptions = {
   path: "/",
   sameSite: "lax",
   httpOnly: false,
-  maxAge: 60 * 60 * 24 * 365 * 1000,
+  // https://developer.chrome.com/blog/cookie-max-age-expires
+  // https://httpwg.org/http-extensions/draft-ietf-httpbis-rfc6265bis.html#name-cookie-lifetime-limits
+  maxAge: 400 * 24 * 60 * 60,
 };


### PR DESCRIPTION
Some browsers didn't like the large number used by the `Max-Age` default cookie option, causing weird behavior. It's now set to [400 days](https://developer.chrome.com/blog/cookie-max-age-expires).