### PR TITLE
fix: add support for storage key

### DIFF
--- a/src/createBrowserClient.ts
+++ b/src/createBrowserClient.ts
@@ -41,7 +41,7 @@ export function createBrowserClient<
     : string & keyof Database,
   Schema extends GenericSchema = Database[SchemaName] extends GenericSchema
     ? Database[SchemaName]
-    : any,
+    : any
 >(
   supabaseUrl: string,
   supabaseKey: string,
@@ -50,7 +50,7 @@ export function createBrowserClient<
     cookieOptions?: CookieOptionsWithName;
     cookieEncoding?: "raw" | "base64url";
     isSingleton?: boolean;
-  },
+  }
 ): SupabaseClient<Database, SchemaName, Schema>;
 
 /**
@@ -65,7 +65,7 @@ export function createBrowserClient<
     : string & keyof Database,
   Schema extends GenericSchema = Database[SchemaName] extends GenericSchema
     ? Database[SchemaName]
-    : any,
+    : any
 >(
   supabaseUrl: string,
   supabaseKey: string,
@@ -74,7 +74,7 @@ export function createBrowserClient<
     cookieOptions?: CookieOptionsWithName;
     cookieEncoding?: "raw" | "base64url";
     isSingleton?: boolean;
-  },
+  }
 ): SupabaseClient<Database, SchemaName, Schema>;
 
 export function createBrowserClient<
@@ -84,7 +84,7 @@ export function createBrowserClient<
     : string & keyof Database,
   Schema extends GenericSchema = Database[SchemaName] extends GenericSchema
     ? Database[SchemaName]
-    : any,
+    : any
 >(
   supabaseUrl: string,
   supabaseKey: string,
@@ -93,7 +93,7 @@ export function createBrowserClient<
     cookieOptions?: CookieOptionsWithName;
     cookieEncoding?: "raw" | "base64url";
     isSingleton?: boolean;
-  },
+  }
 ): SupabaseClient<Database, SchemaName, Schema> {
   // singleton client is created only if isSingleton is set to true, or if isSingleton is not defined and we detect a browser
   const shouldUseSingleton =
@@ -106,7 +106,7 @@ export function createBrowserClient<
 
   if (!supabaseUrl || !supabaseKey) {
     throw new Error(
-      `@supabase/ssr: Your project's URL and API key are required to create a Supabase client!\n\nCheck your Supabase project's API settings to find these values\n\nhttps://supabase.com/dashboard/project/_/settings/api`,
+      `@supabase/ssr: Your project's URL and API key are required to create a Supabase client!\n\nCheck your Supabase project's API settings to find these values\n\nhttps://supabase.com/dashboard/project/_/settings/api`
     );
   }
 
@@ -115,8 +115,10 @@ export function createBrowserClient<
       ...options,
       cookieEncoding: options?.cookieEncoding ?? "base64url",
     },
-    false,
+    false
   );
+
+  const storageKey = options?.auth?.storageKey || options?.cookieOptions?.name;
 
   const client = createClient<Database, SchemaName, Schema>(
     supabaseUrl,
@@ -132,16 +134,14 @@ export function createBrowserClient<
       },
       auth: {
         ...options?.auth,
-        ...(options?.cookieOptions?.name
-          ? { storageKey: options.cookieOptions.name }
-          : null),
+        ...(storageKey ? { storageKey } : null),
         flowType: "pkce",
         autoRefreshToken: isBrowser(),
         detectSessionInUrl: isBrowser(),
         persistSession: true,
         storage,
       },
-    },
+    }
   );
 
   if (shouldUseSingleton) {

--- a/src/createBrowserClient.ts
+++ b/src/createBrowserClient.ts
@@ -41,7 +41,7 @@ export function createBrowserClient<
     : string & keyof Database,
   Schema extends GenericSchema = Database[SchemaName] extends GenericSchema
     ? Database[SchemaName]
-    : any
+    : any,
 >(
   supabaseUrl: string,
   supabaseKey: string,
@@ -50,7 +50,7 @@ export function createBrowserClient<
     cookieOptions?: CookieOptionsWithName;
     cookieEncoding?: "raw" | "base64url";
     isSingleton?: boolean;
-  }
+  },
 ): SupabaseClient<Database, SchemaName, Schema>;
 
 /**
@@ -65,7 +65,7 @@ export function createBrowserClient<
     : string & keyof Database,
   Schema extends GenericSchema = Database[SchemaName] extends GenericSchema
     ? Database[SchemaName]
-    : any
+    : any,
 >(
   supabaseUrl: string,
   supabaseKey: string,
@@ -74,7 +74,7 @@ export function createBrowserClient<
     cookieOptions?: CookieOptionsWithName;
     cookieEncoding?: "raw" | "base64url";
     isSingleton?: boolean;
-  }
+  },
 ): SupabaseClient<Database, SchemaName, Schema>;
 
 export function createBrowserClient<
@@ -84,7 +84,7 @@ export function createBrowserClient<
     : string & keyof Database,
   Schema extends GenericSchema = Database[SchemaName] extends GenericSchema
     ? Database[SchemaName]
-    : any
+    : any,
 >(
   supabaseUrl: string,
   supabaseKey: string,
@@ -93,7 +93,7 @@ export function createBrowserClient<
     cookieOptions?: CookieOptionsWithName;
     cookieEncoding?: "raw" | "base64url";
     isSingleton?: boolean;
-  }
+  },
 ): SupabaseClient<Database, SchemaName, Schema> {
   // singleton client is created only if isSingleton is set to true, or if isSingleton is not defined and we detect a browser
   const shouldUseSingleton =
@@ -106,7 +106,7 @@ export function createBrowserClient<
 
   if (!supabaseUrl || !supabaseKey) {
     throw new Error(
-      `@supabase/ssr: Your project's URL and API key are required to create a Supabase client!\n\nCheck your Supabase project's API settings to find these values\n\nhttps://supabase.com/dashboard/project/_/settings/api`
+      `@supabase/ssr: Your project's URL and API key are required to create a Supabase client!\n\nCheck your Supabase project's API settings to find these values\n\nhttps://supabase.com/dashboard/project/_/settings/api`,
     );
   }
 
@@ -115,7 +115,7 @@ export function createBrowserClient<
       ...options,
       cookieEncoding: options?.cookieEncoding ?? "base64url",
     },
-    false
+    false,
   );
 
   const storageKey = options?.auth?.storageKey || options?.cookieOptions?.name;
@@ -141,7 +141,7 @@ export function createBrowserClient<
         persistSession: true,
         storage,
       },
-    }
+    },
   );
 
   if (shouldUseSingleton) {

--- a/src/createServerClient.ts
+++ b/src/createServerClient.ts
@@ -149,6 +149,7 @@ export function createServerClient<
       },
       true,
     );
+  const storageKey = options?.auth?.storageKey || options?.cookieOptions?.name;
 
   const client = createClient<Database, SchemaName, Schema>(
     supabaseUrl,
@@ -163,9 +164,7 @@ export function createServerClient<
         },
       },
       auth: {
-        ...(options?.cookieOptions?.name
-          ? { storageKey: options.cookieOptions.name }
-          : null),
+        ...(storageKey ? { storageKey } : null),
         ...options?.auth,
         flowType: "pkce",
         autoRefreshToken: false,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Address #19 to allow developer to configure `storageKey` when using `createBrowserClient()` client side. Not relevant for server-side as cookies are used there.