### PR TITLE
fix: add @types/cookies to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
+        "@types/cookie": "^0.6.0",
         "cookie": "^0.6.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.3.0",
         "@supabase/supabase-js": "^2.43.4",
-        "@types/cookie": "^0.6.0",
         "@vitest/coverage-v8": "^1.6.0",
         "eslint": "^8.57.0",
         "prettier": "^3.2.5",
@@ -374,8 +374,7 @@
     "node_modules/@types/cookie": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
-      "dev": true
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="
     },
     "node_modules/@types/estree": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   "devDependencies": {
     "@eslint/js": "^9.3.0",
     "@supabase/supabase-js": "^2.43.4",
-    "@types/cookie": "^0.6.0",
     "@vitest/coverage-v8": "^1.6.0",
     "eslint": "^8.57.0",
     "prettier": "^3.2.5",
@@ -46,6 +45,7 @@
     "@supabase/supabase-js": "^2.43.4"
   },
   "dependencies": {
-    "cookie": "^0.6.0"
+    "cookie": "^0.6.0",
+    "@types/cookie": "^0.6.0"
   }
 }


### PR DESCRIPTION
Makes the `@types/cookies` dependency a regular one to fix common compilation errors. See #53.
