### PR TITLE
chore: workflow cleanup

### DIFF
--- a/.github/workflows/conventional-commits-lint.js
+++ b/.github/workflows/conventional-commits-lint.js
@@ -16,7 +16,7 @@ const ALLOWED_CONVENTIONAL_COMMIT_PREFIXES = [
 ];
 
 const object = process.argv[2];
-const payload = JSON.parse(fs.readFileSync(process.stdin.fd, "utf-8"));
+const payload = JSON.parse(fs.readFileSync(process.argv[3], "utf-8"));
 
 let validate = [];
 

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -16,10 +16,15 @@ on:
       - reopened
       - ready_for_review
 
+permissions:
+  contents: read
+
 jobs:
   check-conventional-commits:
     runs-on: ubuntu-latest
-
+    if: github.actor != 'dependabot[bot]' # skip for dependabot PRs
+    env:
+      EVENT: ${{ toJSON(github.event) }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -29,15 +34,14 @@ jobs:
       - if: ${{ github.event_name == 'pull_request_target' }}
         run: |
           set -ex
-
-          node .github/workflows/conventional-commits-lint.js pr <<EOF
-          ${{ toJSON(github.event) }}
-          EOF
+          TMP_FILE=$(mktemp)
+          echo "${EVENT}" > "$TMP_FILE"
+          node .github/workflows/conventional-commits-lint.js pr "${TMP_FILE}"
 
       - if: ${{ github.event_name == 'push' }}
         run: |
           set -ex
 
-          node .github/workflows/conventional-commits-lint.js push <<EOF
-          ${{ toJSON(github.event) }}
-          EOF
+          TMP_FILE=$(mktemp)
+          echo "${EVENT}" > "$TMP_FILE"
+          node .github/workflows/conventional-commits-lint.js push "${TMP_FILE}"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix, and maintenance to CI

## What is the current behavior?

The `github.event` could include shell characters such as ``` in the commit message, which would be interpreted by the shell and can lead to unexpected code execution. Dependabot PRs break because of commit title rules, skip.

## What is the new behavior?

Uses intermediate file for getting `github.event` information. Direct shell interpretation doesn't escape special characters, which can cause problems or lead to code execution. Skips the job for dependabot PRs.
