### PR TITLE
fix: add `create*Client` string in `x-client-info`

### DIFF
--- a/src/createBrowserClient.ts
+++ b/src/createBrowserClient.ts
@@ -127,7 +127,7 @@ export function createBrowserClient<
         ...options?.global,
         headers: {
           ...options?.global?.headers,
-          "X-Client-Info": `supabase-ssr/${VERSION}`,
+          "X-Client-Info": `supabase-ssr/${VERSION} createBrowserClient`,
         },
       },
       auth: {

--- a/src/createServerClient.ts
+++ b/src/createServerClient.ts
@@ -159,7 +159,7 @@ export function createServerClient<
         ...options?.global,
         headers: {
           ...options?.global?.headers,
-          "X-Client-Info": `supabase-ssr/${VERSION}`,
+          "X-Client-Info": `supabase-ssr/${VERSION} createServerClient`,
         },
       },
       auth: {


### PR DESCRIPTION
A tiny change that lets Supabase team track usage of `createServerClient` and `createBrowserClient` separately across requests.