### PR TITLE
feat: bump `cookie` to 1.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "cookie": "^1.0.1"
+        "cookie": "^1.0.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.3.0",
@@ -1558,9 +1558,10 @@
       "dev": true
     },
     "node_modules/cookie": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.1.tgz",
-      "integrity": "sha512-Xd8lFX4LM9QEEwxQpF9J9NTUh8pmdJO0cyRJhFiDoLTk2eH8FXlRv2IFGYVadZpqI3j8fhNrSdKCeYPxiAhLXw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
     "@supabase/supabase-js": "^2.43.4"
   },
   "dependencies": {
-    "cookie": "^1.0.1"
+    "cookie": "^1.0.2"
   }
 }


### PR DESCRIPTION
Bumps [`cookie`](https://www.npmjs.com/package/cookie) to 1.0.2 which supports [CHIPS](https://datatracker.ietf.org/doc/html/draft-cutler-httpbis-partitioned-cookies/) cookies.
