### PR TITLE
feat: adds `cookies.encode` option allowing minimal cookie sizes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.3.0",
-        "@supabase/supabase-js": "^2.43.4",
+        "@supabase/supabase-js": "^2.57.4",
         "@types/node": "^24.3.0",
         "@vitest/coverage-v8": "^1.6.0",
         "eslint": "^8.57.0",
@@ -898,9 +898,9 @@
       "dev": true
     },
     "node_modules/@supabase/auth-js": {
-      "version": "2.64.2",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.64.2.tgz",
-      "integrity": "sha512-s+lkHEdGiczDrzXJ1YWt2y3bxRi+qIUnXcgkpLSrId7yjBeaXBFygNjTaoZLG02KNcYwbuZ9qkEIqmj2hF7svw==",
+      "version": "2.71.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.71.1.tgz",
+      "integrity": "sha512-mMIQHBRc+SKpZFRB2qtupuzulaUhFYupNyxqDj5Jp/LyPvcWvjaJzZzObv6URtL/O6lPxkanASnotGtNpS3H2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -908,9 +908,9 @@
       }
     },
     "node_modules/@supabase/functions-js": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.3.1.tgz",
-      "integrity": "sha512-QyzNle/rVzlOi4BbVqxLSH828VdGY1RElqGFAj+XeVypj6+PVtMlD21G8SDnsPQDtlqqTtoGRgdMlQZih5hTuw==",
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.6.tgz",
+      "integrity": "sha512-bhjZ7rmxAibjgmzTmQBxJU6ZIBCCJTc3Uwgvdi4FewueUTAGO5hxZT1Sj6tiD+0dSXf9XI87BDdJrg12z8Uaew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -931,9 +931,9 @@
       }
     },
     "node_modules/@supabase/postgrest-js": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.15.2.tgz",
-      "integrity": "sha512-9/7pUmXExvGuEK1yZhVYXPZnLEkDTwxgMQHXLrN5BwPZZm4iUCL1YEyep/Z2lIZah8d8M433mVAUEGsihUj5KQ==",
+      "version": "1.21.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.21.4.tgz",
+      "integrity": "sha512-TxZCIjxk6/dP9abAi89VQbWWMBbybpGWyvmIzTd79OeravM13OjR/YEYeyUOPcM1C3QyvXkvPZhUfItvmhY1IQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -941,22 +941,22 @@
       }
     },
     "node_modules/@supabase/realtime-js": {
-      "version": "2.9.5",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.9.5.tgz",
-      "integrity": "sha512-TEHlGwNGGmKPdeMtca1lFTYCedrhTAv3nZVoSjrKQ+wkMmaERuCe57zkC5KSWFzLYkb5FVHW8Hrr+PX1DDwplQ==",
+      "version": "2.15.5",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.15.5.tgz",
+      "integrity": "sha512-/Rs5Vqu9jejRD8ZeuaWXebdkH+J7V6VySbCZ/zQM93Ta5y3mAmocjioa/nzlB6qvFmyylUgKVS1KpE212t30OA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@supabase/node-fetch": "^2.6.14",
-        "@types/phoenix": "^1.5.4",
-        "@types/ws": "^8.5.10",
-        "ws": "^8.14.2"
+        "@supabase/node-fetch": "^2.6.13",
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "ws": "^8.18.2"
       }
     },
     "node_modules/@supabase/storage-js": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.5.5.tgz",
-      "integrity": "sha512-OpLoDRjFwClwc2cjTJZG8XviTiQH4Ik8sCiMK5v7et0MDu2QlXjCAW3ljxJB5+z/KazdMOTnySi+hysxWUPu3w==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.12.1.tgz",
+      "integrity": "sha512-QWg3HV6Db2J81VQx0PqLq0JDBn4Q8B1FYn1kYcbla8+d5WDmTdwwMr+EJAxNOSs9W4mhKMv+EYCpCrTFlTj4VQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -964,18 +964,18 @@
       }
     },
     "node_modules/@supabase/supabase-js": {
-      "version": "2.43.4",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.43.4.tgz",
-      "integrity": "sha512-/pLPaxiIsn5Vaz3s32HC6O/VNwfeddnzS0bZRpOW0AKcPuXroD8pT9G8mpiBlZfpKsMmq6k7tlhW7Sr1PAQ1lw==",
+      "version": "2.57.4",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.57.4.tgz",
+      "integrity": "sha512-LcbTzFhHYdwfQ7TRPfol0z04rLEyHabpGYANME6wkQ/kLtKNmI+Vy+WEM8HxeOZAtByUFxoUTTLwhXmrh+CcVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@supabase/auth-js": "2.64.2",
-        "@supabase/functions-js": "2.3.1",
+        "@supabase/auth-js": "2.71.1",
+        "@supabase/functions-js": "2.4.6",
         "@supabase/node-fetch": "2.6.15",
-        "@supabase/postgrest-js": "1.15.2",
-        "@supabase/realtime-js": "2.9.5",
-        "@supabase/storage-js": "2.5.5"
+        "@supabase/postgrest-js": "1.21.4",
+        "@supabase/realtime-js": "2.15.5",
+        "@supabase/storage-js": "2.12.1"
       }
     },
     "node_modules/@types/estree": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "homepage": "https://github.com/supabase/ssr#readme",
   "devDependencies": {
     "@eslint/js": "^9.3.0",
-    "@supabase/supabase-js": "^2.43.4",
+    "@supabase/supabase-js": "^2.57.4",
     "@types/node": "^24.3.0",
     "@vitest/coverage-v8": "^1.6.0",
     "eslint": "^8.57.0",

--- a/src/createBrowserClient.ts
+++ b/src/createBrowserClient.ts
@@ -141,6 +141,13 @@ export function createBrowserClient<
       detectSessionInUrl: isBrowser(),
       persistSession: true,
       storage,
+      ...(options?.cookies &&
+      "encode" in options.cookies &&
+      options.cookies.encode === "tokens-only"
+        ? {
+            userStorage: options?.auth?.userStorage ?? window.localStorage,
+          }
+        : null),
     },
   });
 

--- a/src/createServerClient.ts
+++ b/src/createServerClient.ts
@@ -12,6 +12,7 @@ import type {
   CookieMethodsServer,
   CookieMethodsServerDeprecated,
 } from "./types";
+import { memoryLocalStorageAdapter } from "./utils/helpers";
 
 /**
  * @deprecated Please specify `getAll` and `setAll` cookie methods instead of
@@ -170,6 +171,14 @@ export function createServerClient<
       detectSessionInUrl: false,
       persistSession: true,
       storage,
+      ...(options?.cookies &&
+      "encode" in options.cookies &&
+      options.cookies.encode === "tokens-only"
+        ? {
+            userStorage:
+              options?.auth?.userStorage ?? memoryLocalStorageAdapter(),
+          }
+        : null),
     },
   });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,15 @@ export type CookieMethodsBrowserDeprecated = {
 };
 
 export type CookieMethodsBrowser = {
+  /**
+   * If set to true, only the user's session (access and refresh tokens) will be encoded in cookies. The user object will be encoded in local storage if the `userStorage` option is not provided when creating the client.
+   *
+   * You should keep this option the same between `createBrowserClient()` and `createServerClient()`. When set to `tokens-only` accessing the `user` property on the data returned from `getSession()` will only be possible if the user has already been stored in the separate storage. It's best to use `getClaims()` instead to avoid surprizes.
+   *
+   * @experimental
+   */
+  encode?: "user-and-tokens" | "tokens-only";
+
   getAll: GetAllCookies;
   setAll: SetAllCookies;
 };
@@ -44,6 +53,15 @@ export type CookieMethodsServerDeprecated = {
 };
 
 export type CookieMethodsServer = {
+  /**
+   * If set to `tokens-only`, only the user's access and refresh tokens will be encoded in cookies. The user object will be encoded in memory if the `userStorage` option is not provided when creating the client. Unset value defaults to `user-and-tokens`.
+   *
+   * You should keep this option the same between `createBrowserClient()` and `createServerClient()`. When set to `tokens-only` accessing the `user` property on the data returned from `getSession()` will not be possible. Use `getUser()` or preferably `getClaims()` instead.
+   *
+   * @experimental
+   */
+  encode?: "user-and-tokens" | "tokens-only";
+
   getAll: GetAllCookies;
   setAll?: SetAllCookies;
 };

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -51,3 +51,25 @@ export function isBrowser() {
     typeof window !== "undefined" && typeof window.document !== "undefined"
   );
 }
+
+/**
+ * Returns a localStorage-like object that stores the key-value pairs in
+ * memory.
+ */
+export function memoryLocalStorageAdapter(
+  store: { [key: string]: string } = {},
+) {
+  return {
+    getItem: (key: string) => {
+      return store[key] || null;
+    },
+
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+  };
+}


### PR DESCRIPTION
Adds an experimental option `encode` on the `cookies` object when using `createBrowserClient()` and `createServerClient()`.

If this is set to `tokens-only` then only the user's access token and refresh token will be encoded in the cookies, causing significant cookie size savings, often greater than 50%. It utilizes [split session storage in `auth-js`](https://github.com/supabase/supabase-js/pull/1545), with some trade-offs such as the inability to access the `user` property on the `supabase.auth.getSession()` object in the server. This wasn't supposed to be done anyway, and `getClaims()` is a secure alternative for it.