### PR TITLE
chore: use simple version tags for release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,8 @@
     ".": {
       "release-type": "node",
       "package-name": "@supabase/ssr",
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "include-component-in-tag": false
     }
   }
 }


### PR DESCRIPTION
Add `include-component-in-tag: false` to match existing v0.8.0 tag format. Without this, release-please looks for ssr-v0.8.0 tags and can't find the release history.