### PR TITLE
fix: disable session persistence for service role keys

### DIFF
--- a/src/createServerClient.ts
+++ b/src/createServerClient.ts
@@ -13,6 +13,20 @@ import type {
   CookieMethodsServerDeprecated,
 } from "./types";
 import { memoryLocalStorageAdapter } from "./utils/helpers";
+import { stringFromBase64URL } from "./utils/base64url";
+
+function isServiceRoleKey(apiKey: string): boolean {
+  try {
+    const parts = apiKey.split(".");
+    if (parts.length !== 3) {
+      return false;
+    }
+    const payload = JSON.parse(stringFromBase64URL(parts[1]));
+    return payload.role === "service_role";
+  } catch {
+    return false;
+  }
+}
 
 /**
  * @deprecated Please specify `getAll` and `setAll` cookie methods instead of
@@ -142,6 +156,8 @@ export function createServerClient<
     );
   }
 
+  const isServiceRole = isServiceRoleKey(supabaseKey);
+
   const { storage, getAll, setAll, setItems, removedItems } =
     createStorageFromOptions(
       {
@@ -169,7 +185,7 @@ export function createServerClient<
       flowType: "pkce",
       autoRefreshToken: false,
       detectSessionInUrl: false,
-      persistSession: true,
+      persistSession: !isServiceRole,
       storage,
       ...(options?.cookies &&
       "encode" in options.cookies &&


### PR DESCRIPTION
when using a service role key with `createServerClient`, the client was reading user sessions from cookies and using that token for authorization instead of the service role key. this caused `rls` to be applied even though service role keys should bypass it.

this fix detects service role keys by checking the` jwt `payload and disables` persistSession`, ensuring the `service role key` is used directly for all requests.

fixes the 403 unauthorized error on storage operations when using secret keys.

closes https://github.com/supabase/ssr/issues/141