### PR TITLE
fix(auth): respect user-provided auth options in createBrowserClient

### DIFF
--- a/src/createBrowserClient.spec.ts
+++ b/src/createBrowserClient.spec.ts
@@ -1,10 +1,24 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import { MAX_CHUNK_SIZE, stringToBase64URL } from "./utils";
 import { CookieOptions } from "./types";
 import { createBrowserClient } from "./createBrowserClient";
 
-describe("createServerClient", () => {
+// Spy on createClient to capture auth options passed through
+const createClientSpy = vi.fn().mockReturnValue({
+  auth: {},
+  realtime: {},
+});
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: (...args: any[]) => createClientSpy(...args),
+}));
+
+describe("createBrowserClient", () => {
+  beforeEach(() => {
+    createClientSpy.mockClear();
+  });
+
   describe("validation", () => {
     it("should throw an error on empty URL and anon key", async () => {
       expect(() => {
@@ -14,6 +28,48 @@ describe("createServerClient", () => {
       expect(() => {
         createBrowserClient("", "anon key");
       }).toThrow();
+    });
+  });
+
+  describe("auth options passthrough", () => {
+    it("should respect autoRefreshToken when explicitly set to false", () => {
+      createBrowserClient("http://localhost", "anon-key", {
+        isSingleton: false,
+        auth: { autoRefreshToken: false },
+      });
+
+      const passedOptions = createClientSpy.mock.calls[0][2];
+      expect(passedOptions.auth.autoRefreshToken).toBe(false);
+    });
+
+    it("should respect detectSessionInUrl when explicitly set to false", () => {
+      createBrowserClient("http://localhost", "anon-key", {
+        isSingleton: false,
+        auth: { detectSessionInUrl: false },
+      });
+
+      const passedOptions = createClientSpy.mock.calls[0][2];
+      expect(passedOptions.auth.detectSessionInUrl).toBe(false);
+    });
+
+    it("should respect persistSession when explicitly set to false", () => {
+      createBrowserClient("http://localhost", "anon-key", {
+        isSingleton: false,
+        auth: { persistSession: false },
+      });
+
+      const passedOptions = createClientSpy.mock.calls[0][2];
+      expect(passedOptions.auth.persistSession).toBe(false);
+    });
+
+    it("should use defaults when auth options are not provided", () => {
+      createBrowserClient("http://localhost", "anon-key", {
+        isSingleton: false,
+      });
+
+      const passedOptions = createClientSpy.mock.calls[0][2];
+      // defaults come from isBrowser() for autoRefreshToken/detectSessionInUrl, true for persistSession
+      expect(passedOptions.auth.persistSession).toBe(true);
     });
   });
 });

--- a/src/createBrowserClient.ts
+++ b/src/createBrowserClient.ts
@@ -137,9 +137,9 @@ export function createBrowserClient<
         ? { storageKey: options.cookieOptions.name }
         : null),
       flowType: "pkce",
-      autoRefreshToken: isBrowser(),
-      detectSessionInUrl: isBrowser(),
-      persistSession: true,
+      autoRefreshToken: options?.auth?.autoRefreshToken ?? isBrowser(),
+      detectSessionInUrl: options?.auth?.detectSessionInUrl ?? isBrowser(),
+      persistSession: options?.auth?.persistSession ?? true,
       storage,
       ...(options?.cookies &&
       "encode" in options.cookies &&


### PR DESCRIPTION
## Summary
- `createBrowserClient` hardcodes `autoRefreshToken`, `detectSessionInUrl`, and `persistSession` after spreading `options.auth`, overwriting any caller-provided values
- Use nullish coalescing (`??`) so explicit options are respected, falling back to current defaults (`isBrowser()` / `true`) when not set
- Adds tests verifying passthrough of all three options

Fixes https://github.com/supabase/ssr/issues/108