### PR TITLE
feat!: enforce headers parameter on setAll cookie method

### DIFF
--- a/src/cookies.spec.ts
+++ b/src/cookies.spec.ts
@@ -226,7 +226,7 @@ describe("createStorageFromOptions for createServerClient", () => {
               return [];
             },
 
-            setAll: async () => {
+            setAll: async (_cookies, _headers) => {
               setAllCalled = true;
             },
           },
@@ -252,7 +252,7 @@ describe("createStorageFromOptions for createServerClient", () => {
               return [];
             },
 
-            setAll: async () => {
+            setAll: async (_cookies, _headers) => {
               setAllCalled = true;
             },
           },
@@ -280,7 +280,7 @@ describe("createStorageFromOptions for createServerClient", () => {
               return [];
             },
 
-            setAll: async () => {},
+            setAll: async (_cookies, _headers) => {},
           },
         },
         true,
@@ -307,7 +307,7 @@ describe("createStorageFromOptions for createServerClient", () => {
               return [];
             },
 
-            setAll: async () => {},
+            setAll: async (_cookies, _headers) => {},
           },
         },
         true,
@@ -334,7 +334,7 @@ describe("createStorageFromOptions for createServerClient", () => {
               return [];
             },
 
-            setAll: async () => {},
+            setAll: async (_cookies, _headers) => {},
           },
         },
         true,
@@ -377,7 +377,7 @@ describe("createStorageFromOptions for createServerClient", () => {
               ];
             },
 
-            setAll: async () => {},
+            setAll: async (_cookies, _headers) => {},
           },
         },
         true,
@@ -418,7 +418,7 @@ describe("createStorageFromOptions for createServerClient", () => {
               ];
             },
 
-            setAll: async () => {},
+            setAll: async (_cookies, _headers) => {},
           },
         },
         true,
@@ -577,7 +577,7 @@ describe("createStorageFromOptions for createBrowserClient", () => {
               ];
             },
 
-            setAll: async () => {},
+            setAll: async (_cookies, _headers) => {},
           },
         },
         false,
@@ -607,7 +607,7 @@ describe("createStorageFromOptions for createBrowserClient", () => {
               return [];
             },
 
-            setAll: async () => {
+            setAll: async (_cookies, _headers) => {
               setAllCalls += 1;
             },
           },
@@ -640,7 +640,7 @@ describe("createStorageFromOptions for createBrowserClient", () => {
               ];
             },
 
-            setAll: async () => {
+            setAll: async (_cookies, _headers) => {
               setAllCalls += 1;
             },
           },
@@ -682,7 +682,7 @@ describe("createStorageFromOptions for createBrowserClient", () => {
               ];
             },
 
-            setAll: async (setCookies) => {
+            setAll: async (setCookies, _headers) => {
               setAllCalls.push(...setCookies);
             },
           },
@@ -753,7 +753,7 @@ describe("createStorageFromOptions for createBrowserClient", () => {
               ];
             },
 
-            setAll: async (setCookies) => {
+            setAll: async (setCookies, _headers) => {
               setAllCalls.push(...setCookies);
             },
           },
@@ -828,7 +828,7 @@ describe("createStorageFromOptions for createBrowserClient", () => {
               ];
             },
 
-            setAll: async (setCookies) => {
+            setAll: async (setCookies, _headers) => {
               setAllCalls.push(...setCookies);
             },
           },
@@ -903,7 +903,7 @@ describe("createStorageFromOptions for createBrowserClient", () => {
               ];
             },
 
-            setAll: async (setCookies) => {
+            setAll: async (setCookies, _headers) => {
               setAllCalls.push(...setCookies);
             },
           },
@@ -941,6 +941,84 @@ describe("createStorageFromOptions for createBrowserClient", () => {
         },
       ]);
     });
+  });
+});
+
+describe("setAll arity enforcement", () => {
+  it("should throw when setAll accepts zero parameters (server)", () => {
+    expect(() => {
+      createStorageFromOptions(
+        {
+          cookieEncoding: "raw",
+          cookies: {
+            getAll: async () => [],
+            setAll: async () => {},
+          },
+        },
+        true,
+      );
+    }).toThrow(/must accept two parameters/);
+  });
+
+  it("should throw when setAll accepts one parameter (server)", () => {
+    expect(() => {
+      createStorageFromOptions(
+        {
+          cookieEncoding: "raw",
+          cookies: {
+            getAll: async () => [],
+            setAll: async (_cookies: any) => {},
+          },
+        },
+        true,
+      );
+    }).toThrow(/must accept two parameters/);
+  });
+
+  it("should throw when setAll accepts zero parameters (browser)", () => {
+    expect(() => {
+      createStorageFromOptions(
+        {
+          cookieEncoding: "raw",
+          cookies: {
+            getAll: async () => [],
+            setAll: async () => {},
+          },
+        },
+        false,
+      );
+    }).toThrow(/must accept two parameters/);
+  });
+
+  it("should not throw when setAll accepts two parameters", () => {
+    expect(() => {
+      createStorageFromOptions(
+        {
+          cookieEncoding: "raw",
+          cookies: {
+            getAll: async () => [],
+            setAll: async (_cookies: any, _headers: any) => {},
+          },
+        },
+        true,
+      );
+    }).not.toThrow();
+  });
+
+  it("should not throw for deprecated get/set/remove path", () => {
+    expect(() => {
+      createStorageFromOptions(
+        {
+          cookieEncoding: "raw",
+          cookies: {
+            get: async () => null,
+            set: async () => {},
+            remove: async () => {},
+          },
+        },
+        true,
+      );
+    }).not.toThrow();
   });
 });
 

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -115,7 +115,16 @@ export function createStorageFromOptions(
       getAll = async () => await cookies.getAll!();
 
       if ("setAll" in cookies) {
-        setAll = cookies.setAll!;
+        const userSetAll = cookies.setAll!;
+        if (userSetAll.length < 2) {
+          throw new Error(
+            `@supabase/ssr: The setAll cookie method must accept two parameters: (cookies, headers). ` +
+              `Your function only accepts ${userSetAll.length}. The second parameter contains cache-control ` +
+              `headers that must be forwarded to the HTTP response to prevent CDNs from caching ` +
+              `authenticated responses. See https://supabase.com/docs/guides/auth/server-side/creating-a-client for examples.`,
+          );
+        }
+        setAll = userSetAll;
       } else if (isServerClient) {
         setAll = async () => {
           console.warn(

--- a/src/createServerClient.spec.ts
+++ b/src/createServerClient.spec.ts
@@ -14,7 +14,7 @@ describe("createServerClient", () => {
               return [];
             },
 
-            setAll(cookiesToSet) {
+            setAll(cookiesToSet, _headers) {
               // no-op
             },
           },
@@ -28,7 +28,7 @@ describe("createServerClient", () => {
               return [];
             },
 
-            setAll(cookiesToSet) {
+            setAll(cookiesToSet, _headers) {
               // no-op
             },
           },
@@ -63,7 +63,7 @@ describe("createServerClient", () => {
                 return [];
               },
 
-              setAll(cookiesToSet) {
+              setAll(cookiesToSet, _headers) {
                 setAllCalls += 1;
                 setCookies.push(...cookiesToSet);
               },
@@ -127,7 +127,7 @@ describe("createServerClient", () => {
                 ];
               },
 
-              setAll(cookiesToSet) {
+              setAll(cookiesToSet, _headers) {
                 setAllCalls += 1;
                 setCookies.push(...cookiesToSet);
               },
@@ -221,7 +221,7 @@ describe("createServerClient", () => {
                 ];
               },
 
-              setAll(cookiesToSet) {
+              setAll(cookiesToSet, _headers) {
                 setAllCalls += 1;
                 setCookies.push(...cookiesToSet);
               },
@@ -329,7 +329,7 @@ describe("createServerClient", () => {
                 ];
               },
 
-              setAll(cookiesToSet) {
+              setAll(cookiesToSet, _headers) {
                 setAllCalls += 1;
               },
             },
@@ -410,7 +410,7 @@ describe("createServerClient", () => {
                 ];
               },
 
-              setAll(cookiesToSet) {
+              setAll(cookiesToSet, _headers) {
                 setAllCalls += 1;
               },
             },
@@ -464,7 +464,7 @@ describe("createServerClient", () => {
                   },
                 ];
               },
-              setAll() {},
+              setAll(_cookiesToSet, _headers) {},
             },
 
             global: {
@@ -539,7 +539,7 @@ describe("createServerClient", () => {
                 ];
               },
 
-              setAll(cookiesToSet) {
+              setAll(cookiesToSet, _headers) {
                 setAllCalls += 1;
               },
             },
@@ -599,7 +599,7 @@ describe("createServerClient", () => {
           getAll() {
             return [];
           },
-          setAll() {},
+          setAll(_cookiesToSet, _headers) {},
         },
         global: {
           fetch: async () => {


### PR DESCRIPTION
## Summary

Adds a runtime check that throws at client creation time if the user-provided `setAll` callback declares fewer than two parameters. This enforces that users accept the `headers` second argument introduced in v0.10.0, which carries cache-control headers (`Cache-Control`, `Expires`, `Pragma`) that must be forwarded to the HTTP response after token refreshes.

Without this enforcement, TypeScript silently allows `setAll(cookies) { ... }` to satisfy the `(cookies, headers) => void` type, so users who copy an outdated snippet or skip the changelog never apply the cache headers. CDNs can then cache authenticated responses and serve one user's session token to another.

## What changed

- **`src/cookies.ts`** -- Added `Function.length` arity check at the single point where user-provided `setAll` enters the system. If `setAll.length < 2`, an error with a clear message and docs link is thrown immediately. Library-controlled `setAll` implementations (deprecated `get/set/remove` wrapper, warning stubs, `document.cookie` adapter) are not checked.
- **`src/cookies.spec.ts`** -- Updated 14 test mocks to declare both parameters. Added 5 new tests covering: zero-param throws (server), one-param throws (server), zero-param throws (browser), two-param passes, deprecated `get/set/remove` path is unaffected.
- **`src/createServerClient.spec.ts`** -- Updated 10 test mocks to declare both parameters.

## Breaking change

`setAll` must now declare two parameters `(cookies, headers)`. Existing implementations that only declare one parameter will throw on upgrade. Since the package is on 0.x, this ships as a minor bump (0.11.0) per semver conventions.

## Context

- Root cause: [supabase/supabase-js#1682](https://github.com/supabase/supabase-js/issues/1682)
- Feature PR that introduced the headers param: [supabase/ssr#176](https://github.com/supabase/ssr/pull/176)
- Docs update: [supabase/supabase#44240](https://github.com/supabase/supabase/pull/44240)
- UI library update (open): [supabase/supabase#44351](https://github.com/supabase/supabase/pull/44351)
