### PR TITLE
fix: validate base64-prefixed chunked cookies decode to valid JSON

### DIFF
--- a/src/cookies.spec.ts
+++ b/src/cookies.spec.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 
-import { isBrowser, DEFAULT_COOKIE_OPTIONS, MAX_CHUNK_SIZE } from "./utils";
+import {
+  isBrowser,
+  DEFAULT_COOKIE_OPTIONS,
+  MAX_CHUNK_SIZE,
+  stringToBase64URL,
+} from "./utils";
 import { CookieOptions } from "./types";
 
 import { createStorageFromOptions, applyServerStorage } from "./cookies";
@@ -1086,5 +1091,131 @@ describe("applyServerStorage", () => {
         options: { ...DEFAULT_COOKIE_OPTIONS },
       },
     ]);
+  });
+});
+
+describe("createStorageFromOptions chunked cookie corruption", () => {
+  let warnings: any[][];
+  let warnSpy: any;
+
+  beforeEach(() => {
+    warnings = [];
+    warnSpy = vi.spyOn(console, "warn").mockImplementation((...args: any[]) => {
+      warnings.push(args);
+    });
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  // Splits a single string into N roughly-equal contiguous chunks.
+  const splitInto = (value: string, parts: number): string[] => {
+    const size = Math.ceil(value.length / parts);
+    const out: string[] = [];
+    for (let i = 0; i < parts; i += 1) {
+      out.push(value.slice(i * size, (i + 1) * size));
+    }
+    return out;
+  };
+
+  it("returns null and warns when base64url-prefixed chunks decode to invalid JSON", async () => {
+    // Simulates the issue #169 scenario: combined chunks are valid base64url
+    // (stringFromBase64URL succeeds) but the decoded payload is not JSON.
+    // This is what happens when chunk .0 of a fresh session write gets
+    // concatenated with a stale chunk .1 from a previous session — the bytes
+    // remain in the base64url alphabet but no longer form valid JSON.
+    const garbage = "trailing-garbage-from-previous-session";
+    const payload = "base64-" + stringToBase64URL(garbage);
+
+    const [chunk0, chunk1] = splitInto(payload, 2);
+
+    const { storage } = createStorageFromOptions(
+      {
+        cookieEncoding: "base64url",
+        cookies: {
+          getAll: async () => [
+            { name: "storage-key.0", value: chunk0 },
+            { name: "storage-key.1", value: chunk1 },
+          ],
+          setAll: async () => {},
+        },
+      },
+      true,
+    );
+
+    const value = await storage.getItem("storage-key");
+
+    expect(value).toBeNull();
+    expect(warnings.length).toEqual(1);
+    expect(warnings[0][0]).toMatch(/invalid JSON/);
+  });
+
+  it("returns the decoded value when base64url-prefixed chunks decode to valid JSON", async () => {
+    const session = '{"access_token":"a","refresh_token":"b","expires_at":1}';
+    const payload = "base64-" + stringToBase64URL(session);
+
+    const [chunk0, chunk1] = splitInto(payload, 2);
+
+    const { storage } = createStorageFromOptions(
+      {
+        cookieEncoding: "base64url",
+        cookies: {
+          getAll: async () => [
+            { name: "storage-key.0", value: chunk0 },
+            { name: "storage-key.1", value: chunk1 },
+          ],
+          setAll: async () => {},
+        },
+      },
+      true,
+    );
+
+    const value = await storage.getItem("storage-key");
+
+    expect(value).toEqual(session);
+    expect(warnings).toEqual([]);
+  });
+
+  it("returns null and warns when the base64url payload itself is not decodable", async () => {
+    // A `!` is not a valid base64url character; stringFromBase64URL throws.
+    const { storage } = createStorageFromOptions(
+      {
+        cookieEncoding: "base64url",
+        cookies: {
+          getAll: async () => [
+            { name: "storage-key", value: "base64-not!valid!base64url" },
+          ],
+          setAll: async () => {},
+        },
+      },
+      true,
+    );
+
+    const value = await storage.getItem("storage-key");
+
+    expect(value).toBeNull();
+    expect(warnings.length).toEqual(1);
+    expect(warnings[0][0]).toMatch(/could not base64url-decode/);
+  });
+
+  it("does not validate JSON for raw (non-base64) cookies", async () => {
+    const { storage } = createStorageFromOptions(
+      {
+        cookieEncoding: "raw",
+        cookies: {
+          getAll: async () => [
+            { name: "storage-key", value: "not json at all" },
+          ],
+          setAll: async () => {},
+        },
+      },
+      true,
+    );
+
+    const value = await storage.getItem("storage-key");
+
+    expect(value).toEqual("not json at all");
+    expect(warnings).toEqual([]);
   });
 });

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -24,6 +24,44 @@ import type {
 const BASE64_PREFIX = "base64-";
 
 /**
+ * Decodes a chunked cookie value that may carry the `base64-` prefix written
+ * by this module. When the prefix is present, the underlying payload is always
+ * JSON encoded by auth-js (`setItemAsync` runs `JSON.stringify` on every
+ * write). If the decoded value cannot be parsed as JSON, the chunks are
+ * mismatched (e.g. a partial cookie write left the browser holding a mix of
+ * old and new generations) and we treat the entry as absent so the SDK does
+ * not propagate or re-save the corrupted payload.
+ */
+function decodeChunkedCookieValue(value: string): string | null {
+  if (!value.startsWith(BASE64_PREFIX)) {
+    return value;
+  }
+
+  let decoded: string;
+
+  try {
+    decoded = stringFromBase64URL(value.substring(BASE64_PREFIX.length));
+  } catch (error) {
+    console.warn(
+      "@supabase/ssr: could not base64url-decode chunked cookie value, treating as absent. Cookie chunks may have been written partially across responses.",
+      error,
+    );
+    return null;
+  }
+
+  try {
+    JSON.parse(decoded);
+  } catch {
+    console.warn(
+      "@supabase/ssr: chunked cookie decoded to invalid JSON, treating as absent. This usually indicates that cookie chunks from different writes were combined (e.g. response committed before all Set-Cookie headers were sent).",
+    );
+    return null;
+  }
+
+  return decoded;
+}
+
+/**
  * Creates a storage client that handles cookies correctly for browser and
  * server clients with or without properly provided cookie methods.
  *
@@ -203,15 +241,7 @@ export function createStorageFromOptions(
             return null;
           }
 
-          let decoded = chunkedCookie;
-
-          if (chunkedCookie.startsWith(BASE64_PREFIX)) {
-            decoded = stringFromBase64URL(
-              chunkedCookie.substring(BASE64_PREFIX.length),
-            );
-          }
-
-          return decoded;
+          return decodeChunkedCookieValue(chunkedCookie);
         },
         setItem: async (key: string, value: string) => {
           const allCookies = await getAll([key]);
@@ -343,18 +373,11 @@ export function createStorageFromOptions(
           return null;
         }
 
-        let decoded = chunkedCookie;
-
-        if (
-          typeof chunkedCookie === "string" &&
-          chunkedCookie.startsWith(BASE64_PREFIX)
-        ) {
-          decoded = stringFromBase64URL(
-            chunkedCookie.substring(BASE64_PREFIX.length),
-          );
+        if (typeof chunkedCookie !== "string") {
+          return chunkedCookie;
         }
 
-        return decoded;
+        return decodeChunkedCookieValue(chunkedCookie);
       },
       setItem: async (key: string, value: string) => {
         // We don't have an `onAuthStateChange` event that can let us know that


### PR DESCRIPTION
## Summary

Adds defensive validation to chunked cookie decoding so corrupted or mid-write cookie state no longer propagates a malformed string into `@supabase/auth-js`. When a value is read via the chunked cookie path and carries the `base64-` prefix written by this module, the decoded payload is now verified to be valid JSON (which it always must be, since `setItemAsync` in auth-js writes via `JSON.stringify`). On decode or parse failure we log a console warning and return `null`, signalling the entry is absent so the SDK can recover cleanly instead of crashing or re-saving garbage.

## What changed

- New `decodeChunkedCookieValue` helper in `src/cookies.ts`, used by both the browser and server `getItem` paths inside `createStorageFromOptions`.
- The helper:
  - Returns the value unchanged when there is no `base64-` prefix (raw cookies and PKCE code verifier paths are unaffected).
  - Catches throws from `stringFromBase64URL` and warns: "could not base64url-decode chunked cookie value..."
  - Validates the decoded value parses as JSON; on failure warns: "chunked cookie decoded to invalid JSON..."
  - Returns `null` in either failure case.
- Both `getItem` paths in `createStorageFromOptions` now delegate to this helper.
- Four new tests in `src/cookies.spec.ts` covering: invalid JSON in decoded chunks, valid JSON in decoded chunks, undecodable base64url payload, and that raw (non-base64) cookies are passed through without JSON validation.

## Why

Reported in #169 with a complete root cause analysis from the original reporter. When a session is large enough to span 3+ cookie chunks (`sb-...auth-token.0/.1/.2/...`) and a server side refresh writes only some of the new chunks (e.g. response committed before all `Set-Cookie` headers go out, partial set/remove during SSR, browser racing concurrent navigations), the browser ends up holding chunks from two different generations. `combineChunks` joins them blindly and there are two failure modes downstream:

1. Combined bytes happen to all fall in the base64url alphabet. `stringFromBase64URL` succeeds, but the decoded result is garbage that fails `JSON.parse` later in auth-js. Before the auth-js companion fix, this produced a `TypeError: Cannot create property 'user' on string ...` in `_recoverAndRefresh` and embedded the access token JSON in the error message (token leaked into application error logs).
2. Combined bytes contain a character that is invalid in base64url, e.g. a `.` from a raw JWT segment that landed in a chunk. `stringFromBase64URL` throws synchronously: `Invalid Base64-URL character "." at position N`. This surfaces as an unhandled rejection in production and was reported separately by another customer hitting the same root cause class.

This change catches both failure modes at the source so they never reach auth-js. The corresponding auth-js change (https://github.com/supabase/supabase-js/pull/2312) is the primary fix for the user visible crash from variant 1; this PR is defense in depth and is the actual fix for variant 2.

## Notes for reviewers

- The JSON validation is intentionally narrow: it only runs when the value carries the `base64-` prefix that this module itself writes. Raw cookies (`cookieEncoding: "raw"`), and any cookie value that does not carry the prefix, are returned unchanged. This keeps the change safe for users storing non-JSON values via the storage interface and for the PKCE code verifier path.
- The helper is reused by both the browser and server `getItem`. The server path retained its existing `typeof chunkedCookie !== "string"` defensive shortcut for cases where `combineChunks` might return a non-string at runtime.

## Tracking

- Closes #169
- Closes #87
- Refs https://github.com/supabase/supabase-js/pull/2312 (the auth-js companion fix that prevents the TypeError on the path before this PR's defenses)