### PR TITLE
fix(tsconfig): set explicit rootDir to silence TS6059 in consumer IDEs

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "noImplicitOverride": true,
     "module": "preserve",
     "outDir": "dist/module",
+    "rootDir": "./src",
     "sourceMap": true,
     /* AND if you're building for a library: */
     "declaration": true,


### PR DESCRIPTION
The shipped tsconfig.json sets outDir without rootDir, which causes TypeScript >=5.x to emit a TS6059 hint in consumer IDEs that validate the vendor config. Setting rootDir to ./src matches what TypeScript already infers and follows the team's recommended migration.                                                             
                                                                                                                           
Closes #209   