### PR TITLE
fix: allow cookies encode without getAll/setAll on browser client

### DIFF
--- a/src/cookies.spec.ts
+++ b/src/cookies.spec.ts
@@ -132,6 +132,38 @@ describe("createStorageFromOptions in browser without cookie methods", () => {
       `random-cookie=random;storage-key.0=${newChunkedValue.substring(0, MAX_CHUNK_SIZE)};storage-key.1=${newChunkedValue.substring(MAX_CHUNK_SIZE)}`,
     );
   });
+
+  it("falls back to document.cookie when cookies object only sets encode", async () => {
+    const { storage } = createStorageFromOptions(
+      {
+        cookieEncoding: "raw",
+        cookies: { encode: "tokens-only" },
+      },
+      false,
+    );
+
+    await storage.setItem("storage-key", "value");
+    expect(document.cookie).toEqual("storage-key=value");
+
+    const value = await storage.getItem("storage-key");
+    expect(value).toEqual("value");
+
+    await storage.removeItem("storage-key");
+    expect(document.cookie).toEqual("");
+  });
+
+  it("falls back to document.cookie when cookies object is empty", async () => {
+    const { storage } = createStorageFromOptions(
+      {
+        cookieEncoding: "raw",
+        cookies: {},
+      },
+      false,
+    );
+
+    await storage.setItem("storage-key", "value");
+    expect(document.cookie).toEqual("storage-key=value");
+  });
 });
 
 describe("createStorageFromOptions for createServerClient", () => {

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -52,6 +52,21 @@ export function createStorageFromOptions(
   let getAll: (keyHints: string[]) => ReturnType<GetAllCookies>;
   let setAll: SetAllCookies;
 
+  const documentCookieGetAll = () => {
+    const parsed = parse(document.cookie);
+
+    return Object.keys(parsed).map((name) => ({
+      name,
+      value: parsed[name] ?? "",
+    }));
+  };
+
+  const documentCookieSetAll: SetAllCookies = (setCookies) => {
+    setCookies.forEach(({ name, value, options }) => {
+      document.cookie = serialize(name, value, options);
+    });
+  };
+
   if (cookies) {
     if ("get" in cookies) {
       // Just get is not enough, because the client needs to see what cookies
@@ -127,6 +142,12 @@ export function createStorageFromOptions(
           "@supabase/ssr: createBrowserClient requires configuring both getAll and setAll cookie methods (deprecated: alternatively both get, set and remove can be used)",
         );
       }
+    } else if (!isServerClient && isBrowser()) {
+      // cookies object provided (e.g. just to set `encode`) but no accessors.
+      // Fall through to document.cookie defaults, same as when cookies isn't
+      // provided at all.
+      getAll = () => documentCookieGetAll();
+      setAll = documentCookieSetAll;
     } else {
       // neither get nor getAll is present on cookies, only will occur if pure JavaScript is used, but cookies is an object
       throw new Error(
@@ -135,23 +156,8 @@ export function createStorageFromOptions(
     }
   } else if (!isServerClient && isBrowser()) {
     // The environment is browser, so use the document.cookie API to implement getAll and setAll.
-
-    const noHintGetAll = () => {
-      const parsed = parse(document.cookie);
-
-      return Object.keys(parsed).map((name) => ({
-        name,
-        value: parsed[name] ?? "",
-      }));
-    };
-
-    getAll = () => noHintGetAll();
-
-    setAll = (setCookies) => {
-      setCookies.forEach(({ name, value, options }) => {
-        document.cookie = serialize(name, value, options);
-      });
-    };
+    getAll = () => documentCookieGetAll();
+    setAll = documentCookieSetAll;
   } else if (isServerClient) {
     throw new Error(
       "@supabase/ssr: createServerClient must be initialized with cookie options that specify getAll and setAll functions (deprecated, not recommended: alternatively use get, set and remove)",

--- a/src/createBrowserClient.spec.ts
+++ b/src/createBrowserClient.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 import { MAX_CHUNK_SIZE, stringToBase64URL } from "./utils";
 import { CookieOptions } from "./types";
@@ -70,6 +70,91 @@ describe("createBrowserClient", () => {
       const passedOptions = createClientSpy.mock.calls[0][2];
       // defaults come from isBrowser() for autoRefreshToken/detectSessionInUrl, true for persistSession
       expect(passedOptions.auth.persistSession).toBe(true);
+    });
+  });
+
+  describe("encode option without explicit getAll/setAll", () => {
+    beforeEach(() => {
+      const cookies: { [name: string]: string } = {};
+
+      const doc = new Proxy<typeof document>({} as any, {
+        get: (target, prop) => {
+          if (prop === "cookie") {
+            return Object.keys(cookies)
+              .map((key) => `${key}=${cookies[key]}`)
+              .join(";");
+          }
+          return (target as any)[prop];
+        },
+        set: (target, prop, setValue) => {
+          if (prop === "cookie") {
+            const [cookie, ...options] = setValue.split(/\s*;\s*/);
+            const [name, value] = cookie.split("=");
+            if (options.indexOf("Max-Age=0") > -1) {
+              delete cookies[name];
+            } else {
+              cookies[name] = value;
+            }
+            return true;
+          }
+          (target as any)[prop] = setValue;
+          return true;
+        },
+      });
+
+      const localStorageStub = {
+        getItem: (_key: string) => null,
+        setItem: (_key: string, _value: string) => {},
+        removeItem: (_key: string) => {},
+      };
+
+      globalThis.window = {
+        document: doc,
+        localStorage: localStorageStub,
+      } as any;
+      (globalThis as any).document = doc;
+    });
+
+    afterEach(() => {
+      delete (globalThis as any).window;
+      delete (globalThis as any).document;
+    });
+
+    it("accepts cookies: { encode: 'tokens-only' } without getAll/setAll and routes user storage to userStorage", () => {
+      expect(() =>
+        createBrowserClient("http://localhost", "anon-key", {
+          isSingleton: false,
+          cookies: { encode: "tokens-only" },
+        }),
+      ).not.toThrow();
+
+      const passedOptions = createClientSpy.mock.calls[0][2];
+      expect(passedOptions.auth.userStorage).toBeDefined();
+    });
+
+    it("accepts cookies: { encode: 'user-and-tokens' } without getAll/setAll and does not set userStorage", () => {
+      expect(() =>
+        createBrowserClient("http://localhost", "anon-key", {
+          isSingleton: false,
+          cookies: { encode: "user-and-tokens" },
+        }),
+      ).not.toThrow();
+
+      const passedOptions = createClientSpy.mock.calls[0][2];
+      expect(passedOptions.auth.userStorage).toBeUndefined();
+    });
+
+    it("still works when full getAll/setAll are provided", () => {
+      expect(() =>
+        createBrowserClient("http://localhost", "anon-key", {
+          isSingleton: false,
+          cookies: {
+            encode: "tokens-only",
+            getAll: () => [],
+            setAll: () => {},
+          },
+        }),
+      ).not.toThrow();
     });
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,8 +67,20 @@ export type CookieMethodsBrowser = {
    */
   encode?: "user-and-tokens" | "tokens-only";
 
-  getAll: GetAllCookies;
-  setAll: SetAllCookies;
+  /**
+   * Required when reading cookies from a custom store. If both `getAll` and
+   * `setAll` are omitted in a browser runtime, the client falls back to
+   * reading via `document.cookie`. Tokens and PKCE code verifiers are still
+   * persisted in cookies regardless of the `encode` option, so cookie access
+   * (custom or fallback) is required for auth to work.
+   */
+  getAll?: GetAllCookies;
+  /**
+   * Required alongside `getAll` when using a custom cookie store. If both
+   * `getAll` and `setAll` are omitted in a browser runtime, the client falls
+   * back to writing via `document.cookie`.
+   */
+  setAll?: SetAllCookies;
 };
 
 export type CookieMethodsServerDeprecated = {


### PR DESCRIPTION
`createBrowserClient` already falls back to `document.cookie` when `cookies` is omitted, but `encode` lives on the `cookies` object, so opting into `tokens-only` forced users to redeclare `getAll`/`setAll` (or pass no-op stubs that would break auth). The types were stricter than the runtime.                                                                                                        
                                                                                                                           
`getAll` and `setAll` are now optional on `CookieMethodsBrowser`. When both are omitted in a browser, the same document.cookie fallback is used. `CookieMethodsServer` is unchanged (no document.cookie there). The deprecated `get`/`set`/`remove` overload and the partial-omission case (only one of getAll/setAll provided) keep their existing behavior.

Closes #170