### PR TITLE
fix: enable tree-shaking for browser bundles

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "Use the Supabase JavaScript library in popular server-side rendering (SSR) frameworks.",
   "main": "dist/main/index.js",
   "module": "dist/module/index.js",
+  "types": "dist/module/index.d.ts",
+  "sideEffects": false,
   "scripts": {
     "build": "tsc && tsc -p tsconfig.main.json",
     "test": "vitest --coverage"

--- a/src/createBrowserClient.ts
+++ b/src/createBrowserClient.ts
@@ -14,6 +14,7 @@ import type {
 } from "./types";
 
 import { createStorageFromOptions } from "./cookies";
+import { warnIfUsingDeprecatedAuthHelpersPackage } from "./warnDeprecatedPackage";
 
 let cachedBrowserClient: SupabaseClient<any, any, any> | undefined;
 
@@ -98,6 +99,8 @@ export function createBrowserClient<
     isSingleton?: boolean;
   },
 ): SupabaseClient<Database, SchemaName> {
+  warnIfUsingDeprecatedAuthHelpersPackage();
+
   // singleton client is created only if isSingleton is set to true, or if isSingleton is not defined and we detect a browser
   const shouldUseSingleton =
     options?.isSingleton === true ||

--- a/src/createServerClient.ts
+++ b/src/createServerClient.ts
@@ -13,6 +13,7 @@ import type {
   CookieMethodsServerDeprecated,
 } from "./types";
 import { memoryLocalStorageAdapter } from "./utils/helpers";
+import { warnIfUsingDeprecatedAuthHelpersPackage } from "./warnDeprecatedPackage";
 
 /**
  * @deprecated Please specify `getAll` and `setAll` cookie methods instead of
@@ -126,6 +127,8 @@ export function createServerClient<
     cookieEncoding?: "raw" | "base64url";
   },
 ): SupabaseClient<Database, SchemaName> {
+  warnIfUsingDeprecatedAuthHelpersPackage();
+
   if (!supabaseUrl || !supabaseKey) {
     throw new Error(
       `Your project's URL and Key are required to create a Supabase client!\n\nCheck your Supabase project's API settings to find these values\n\nhttps://supabase.com/dashboard/project/_/settings/api`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,37 +1,11 @@
-// Check if this package is being used as one of the deprecated auth-helpers packages
-if (typeof process !== "undefined" && process.env?.npm_package_name) {
-  const packageName = process.env.npm_package_name;
-  const deprecatedPackages = [
-    "@supabase/auth-helpers-nextjs",
-    "@supabase/auth-helpers-react",
-    "@supabase/auth-helpers-remix",
-    "@supabase/auth-helpers-sveltekit",
-  ];
-
-  if (deprecatedPackages.includes(packageName)) {
-    console.warn(`
-╔════════════════════════════════════════════════════════════════════════════╗
-║ ⚠️  IMPORTANT: Package Consolidation Notice                                ║
-║                                                                            ║
-║ The ${packageName.padEnd(35)} package name is deprecated.  ║
-║                                                                            ║
-║ You are now using @supabase/ssr - a unified solution for all frameworks.  ║
-║                                                                            ║
-║ The auth-helpers packages have been consolidated into @supabase/ssr       ║
-║ to provide better maintenance and consistent APIs across frameworks.      ║
-║                                                                            ║
-║ Please update your package.json to use @supabase/ssr directly:            ║
-║   npm uninstall ${packageName.padEnd(42)} ║
-║   npm install @supabase/ssr                                               ║
-║                                                                            ║
-║ For more information, visit:                                              ║
-║ https://supabase.com/docs/guides/auth/server-side                         ║
-╚════════════════════════════════════════════════════════════════════════════╝
-    `);
-  }
-}
+// IMPORTANT: this file MUST stay free of top-level side effects so the
+// package can advertise `"sideEffects": false` in package.json. Any new
+// runtime initialization belongs inside a function called explicitly by a
+// consumer entry point (createBrowserClient / createServerClient), not at
+// module load time.
 
 export * from "./createBrowserClient";
 export * from "./createServerClient";
 export * from "./types";
 export * from "./utils";
+export { warnIfUsingDeprecatedAuthHelpersPackage } from "./warnDeprecatedPackage";

--- a/src/warnDeprecatedPackage.ts
+++ b/src/warnDeprecatedPackage.ts
@@ -1,0 +1,44 @@
+let warned = false;
+
+const DEPRECATED_PACKAGES = [
+  "@supabase/auth-helpers-nextjs",
+  "@supabase/auth-helpers-react",
+  "@supabase/auth-helpers-remix",
+  "@supabase/auth-helpers-sveltekit",
+];
+
+export function warnIfUsingDeprecatedAuthHelpersPackage(): void {
+  if (warned) {
+    return;
+  }
+
+  if (typeof process === "undefined" || !process.env?.npm_package_name) {
+    return;
+  }
+
+  const packageName = process.env.npm_package_name;
+  if (!DEPRECATED_PACKAGES.includes(packageName)) {
+    return;
+  }
+
+  warned = true;
+  console.warn(`
+╔════════════════════════════════════════════════════════════════════════════╗
+║ ⚠️  IMPORTANT: Package Consolidation Notice                                ║
+║                                                                            ║
+║ The ${packageName.padEnd(35)} package name is deprecated.  ║
+║                                                                            ║
+║ You are now using @supabase/ssr - a unified solution for all frameworks.  ║
+║                                                                            ║
+║ The auth-helpers packages have been consolidated into @supabase/ssr       ║
+║ to provide better maintenance and consistent APIs across frameworks.      ║
+║                                                                            ║
+║ Please update your package.json to use @supabase/ssr directly:            ║
+║   npm uninstall ${packageName.padEnd(42)} ║
+║   npm install @supabase/ssr                                               ║
+║                                                                            ║
+║ For more information, visit:                                              ║
+║ https://supabase.com/docs/guides/auth/server-side                         ║
+╚════════════════════════════════════════════════════════════════════════════╝
+    `);
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix. Closes #92.

## What is the current behavior?

`@supabase/ssr` is not tree-shakeable. A browser bundle that imports only `createBrowserClient` still carries `createServerClient` because (a) `package.json` does not declare `"sideEffects": false` and (b) `src/index.ts` runs a top-level `process.env.npm_package_name` check at module load, which is a real side effect.

## What is the new behavior?

- `package.json` declares `"sideEffects": false` (and adds an explicit `"types"` field).
- The deprecated-auth-helpers warning moves into `src/warnDeprecatedPackage.ts` as a function called from `createBrowserClient` and `createServerClient` on first construction, with a once-per-process guard.
- `src/index.ts` is reduced to pure re-exports.

No API changes. The only behavioral shift is the warning timing: first construction instead of module import.

Verified: 81 tests pass, `createServerClient` drops out of an esbuild browser bundle that imports only `createBrowserClient`, the warning fires once and only after a client is constructed.

## Additional context

Subpath exports (`@supabase/ssr/client`, `/server`) were considered and left out: they would be largely cosmetic on top of `"sideEffects": false`, and an `"exports"` map breaks deep imports into internal paths. Worth a deliberate design pass for a future major. The `ws` and `crypto` symbols in the original screenshot come from `@supabase/supabase-js` transitives and node-polyfill bundler plugins, neither of which this PR touches.