### PR TITLE
fix: align parseCookieHeader return type with getAll cookie method

### DIFF
--- a/src/utils/helpers.spec.ts
+++ b/src/utils/helpers.spec.ts
@@ -7,6 +7,7 @@ import {
   parseCookieHeader,
   serializeCookieHeader,
 } from "./helpers";
+import type { GetAllCookies } from "../types";
 
 describe("helpers", () => {
   describe("parseCookieHeader", () => {
@@ -15,6 +16,20 @@ describe("helpers", () => {
       expect(
         parseCookieHeader(`a=b;c=${encodeURIComponent(" hello ")};e=f`),
       ).toMatchSnapshot();
+    });
+
+    it("returns string values usable directly as a getAll() method (issue #115)", () => {
+      // Every value is a string (never undefined), including valueless cookies.
+      parseCookieHeader("a=b;c=").forEach(({ value }) =>
+        expect(typeof value).toBe("string"),
+      );
+
+      // Compile-time regression guard: the return type must satisfy the
+      // CookieMethodsServer `getAll` contract, so parseCookieHeader can be
+      // returned directly, e.g.
+      // `getAll() { return parseCookieHeader(headers.get("cookie") ?? "") }`.
+      const getAll: GetAllCookies = () => parseCookieHeader("a=b");
+      expect(getAll()).toBeInstanceOf(Array);
     });
   });
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -22,12 +22,12 @@ export const serialize = cookie.serialize;
  */
 export function parseCookieHeader(
   header: string,
-): { name: string; value?: string }[] {
+): { name: string; value: string }[] {
   const parsed = cookie.parse(header);
 
   return Object.keys(parsed ?? {}).map((name) => ({
     name,
-    value: parsed[name],
+    value: parsed[name] ?? "",
   }));
 }
 


### PR DESCRIPTION
## Description

`parseCookieHeader` returns `{ name: string; value?: string }[]`, but the `getAll` cookie method (`GetAllCookies` in `CookieMethodsServer`) requires `{ name: string; value: string }[]`. As a result, the documented server pattern fails to type-check:

```ts
getAll() {
  return parseCookieHeader(request.headers.get("cookie") ?? "");
  // Type '{ name: string; value?: string }[]' is not assignable to
  // '{ name: string; value: string }[]'.
}
```

## Fix

Normalize the value with `?? ""` and drop the optional from the return type, so `parseCookieHeader` is directly assignable to `getAll`. This mirrors the library's own `documentCookieGetAll`, which already uses `parsed[name] ?? ""`.

For a key returned by `Object.keys(parsed)` the value is always a string at runtime, so this is a no-op for normal cookies and normalizes a valueless cookie (`a=`) to `""` — consistent with `documentCookieGetAll`. Narrowing the return type from `string | undefined` to `string` is not a breaking change for consumers reading the value.

## Testing

- Added a regression test in `helpers.spec.ts` that asserts the returned values are strings and that `parseCookieHeader` satisfies the `GetAllCookies` contract at compile time (`const getAll: GetAllCookies = () => parseCookieHeader("a=b")`), so a future regression fails `tsc`.
- `pnpm build` (tsc), `pnpm test` (87 passed), `pnpm exec prettier --check`, `pnpm exec eslint` — all pass. Existing snapshots unchanged.

Fixes #115
