### PR TITLE
feat(cookies): add clearAuthCookiesAtScopes migration helper

### DIFF
--- a/src/clearAuthCookiesAtScopes.spec.ts
+++ b/src/clearAuthCookiesAtScopes.spec.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_COOKIE_OPTIONS } from "./utils";
+import { CookieOptions } from "./types";
+
+import { clearAuthCookiesAtScopes } from "./clearAuthCookiesAtScopes";
+
+describe("clearAuthCookiesAtScopes", () => {
+  it("is a no-op when no scopes are provided", async () => {
+    const setAllCalls: unknown[] = [];
+
+    await clearAuthCookiesAtScopes({
+      getAll: async () => [{ name: "storage-key", value: "value" }],
+      setAll: async (setCookies) => {
+        setAllCalls.push(...setCookies);
+      },
+      storageKey: "storage-key",
+      scopes: [],
+    });
+
+    expect(setAllCalls).toEqual([]);
+  });
+
+  it("is a no-op when no chunks match the storage key", async () => {
+    const setAllCalls: unknown[] = [];
+
+    await clearAuthCookiesAtScopes({
+      getAll: async () => [{ name: "unrelated-cookie", value: "ignored" }],
+      setAll: async (setCookies) => {
+        setAllCalls.push(...setCookies);
+      },
+      storageKey: "storage-key",
+      scopes: [{ domain: ".example.com" }],
+    });
+
+    expect(setAllCalls).toEqual([]);
+  });
+
+  it("emits one Set-Cookie per chunk × scope", async () => {
+    const setAllCalls: {
+      name: string;
+      value: string;
+      options: CookieOptions;
+    }[] = [];
+
+    await clearAuthCookiesAtScopes({
+      getAll: async () => [
+        { name: "storage-key", value: "value" },
+        { name: "storage-key.0", value: "chunk-0" },
+        { name: "storage-key.1", value: "chunk-1" },
+        { name: "unrelated", value: "ignored" },
+      ],
+      setAll: async (setCookies) => {
+        setAllCalls.push(...setCookies);
+      },
+      storageKey: "storage-key",
+      scopes: [{ domain: ".foo.com" }, { domain: ".bar.com" }],
+    });
+
+    const fooOptions = {
+      ...DEFAULT_COOKIE_OPTIONS,
+      domain: ".foo.com",
+      maxAge: 0,
+    };
+    const barOptions = {
+      ...DEFAULT_COOKIE_OPTIONS,
+      domain: ".bar.com",
+      maxAge: 0,
+    };
+
+    expect(setAllCalls).toEqual([
+      { name: "storage-key", value: "", options: fooOptions },
+      { name: "storage-key.0", value: "", options: fooOptions },
+      { name: "storage-key.1", value: "", options: fooOptions },
+      { name: "storage-key", value: "", options: barOptions },
+      { name: "storage-key.0", value: "", options: barOptions },
+      { name: "storage-key.1", value: "", options: barOptions },
+    ]);
+  });
+
+  it("supports path-only scopes (no domain)", async () => {
+    const setAllCalls: {
+      name: string;
+      value: string;
+      options: CookieOptions;
+    }[] = [];
+
+    await clearAuthCookiesAtScopes({
+      getAll: async () => [{ name: "storage-key", value: "value" }],
+      setAll: async (setCookies) => {
+        setAllCalls.push(...setCookies);
+      },
+      storageKey: "storage-key",
+      scopes: [{ path: "/app" }],
+    });
+
+    expect(setAllCalls).toEqual([
+      {
+        name: "storage-key",
+        value: "",
+        options: { ...DEFAULT_COOKIE_OPTIONS, path: "/app", maxAge: 0 },
+      },
+    ]);
+  });
+
+  it("strips name from cookieOptions to avoid NextJS cookieStore confusion", async () => {
+    const setAllCalls: {
+      name: string;
+      value: string;
+      options: CookieOptions & { name?: string };
+    }[] = [];
+
+    await clearAuthCookiesAtScopes({
+      getAll: async () => [{ name: "storage-key", value: "value" }],
+      setAll: async (setCookies) => {
+        setAllCalls.push(...setCookies);
+      },
+      storageKey: "storage-key",
+      scopes: [
+        // @ts-expect-error simulating a scope object that includes `name`
+        { domain: ".example.com", name: "leaked-name" },
+      ],
+    });
+
+    expect(setAllCalls).toHaveLength(1);
+    expect(setAllCalls[0].options.name).toBeUndefined();
+  });
+});

--- a/src/clearAuthCookiesAtScopes.ts
+++ b/src/clearAuthCookiesAtScopes.ts
@@ -1,0 +1,77 @@
+import { DEFAULT_COOKIE_OPTIONS, isChunkLike } from "./utils";
+import type { CookieOptions, GetAllCookies, SetAllCookies } from "./types";
+
+/**
+ * One-shot helper to clear Supabase auth cookies at one or more explicit
+ * scopes. Use after a deploy that changes cookie `Domain`, `Path`, or other
+ * scope-affecting options, to remove stale cookies that the runtime `signOut`
+ * cannot reach because they live at a different scope.
+ *
+ * The helper issues a `Set-Cookie` with `Max-Age=0` for every known chunk of
+ * the given `storageKey` at each scope. The browser silently ignores
+ * `Set-Cookie` attempts for scopes the current host doesn't own, so passing
+ * more scopes than necessary is safe — only the ones that actually held
+ * stale cookies will have any observable effect.
+ *
+ * For the common host-only -> parent-domain migration, this helper is not
+ * required: `signOut` already clears the host-only counterpart automatically
+ * when `cookieOptions.domain` is set on the current client.
+ *
+ * @example
+ *   // After migrating from `.foo.com` to `.bar.com`:
+ *   await clearAuthCookiesAtScopes({
+ *     getAll,
+ *     setAll,
+ *     storageKey: 'sb-<project-ref>-auth-token',
+ *     scopes: [{ domain: '.foo.com' }],
+ *   });
+ *
+ * @example
+ *   // Path migration from `/app` to `/`:
+ *   await clearAuthCookiesAtScopes({
+ *     getAll,
+ *     setAll,
+ *     storageKey: 'sb-<project-ref>-auth-token',
+ *     scopes: [{ path: '/app' }],
+ *   });
+ */
+export async function clearAuthCookiesAtScopes(input: {
+  getAll: (keyHints: string[]) => ReturnType<GetAllCookies>;
+  setAll: SetAllCookies;
+  storageKey: string;
+  scopes: Array<Partial<CookieOptions>>;
+}): Promise<void> {
+  const { getAll, setAll, storageKey, scopes } = input;
+
+  if (scopes.length === 0) {
+    return;
+  }
+
+  const allCookies = (await getAll([storageKey])) ?? [];
+  const chunkNames = allCookies
+    .map(({ name }) => name)
+    .filter((name) => isChunkLike(name, storageKey));
+
+  if (chunkNames.length === 0) {
+    return;
+  }
+
+  const toSet = scopes.flatMap((scope) => {
+    const cookieOptions = {
+      ...DEFAULT_COOKIE_OPTIONS,
+      ...scope,
+      maxAge: 0,
+    };
+
+    // Same NextJS cookieStore guard as createStorageFromOptions.
+    delete (cookieOptions as { name?: string }).name;
+
+    return chunkNames.map((name) => ({
+      name,
+      value: "",
+      options: cookieOptions,
+    }));
+  });
+
+  await setAll(toSet, {});
+}

--- a/src/cookies.spec.ts
+++ b/src/cookies.spec.ts
@@ -1251,3 +1251,244 @@ describe("createStorageFromOptions chunked cookie corruption", () => {
     expect(warnings).toEqual([]);
   });
 });
+
+describe("host-only also-clear when cookieOptions.domain is set", () => {
+  describe("browser client removeItem", () => {
+    it("emits one Set-Cookie per chunk when no domain is configured (baseline)", async () => {
+      const setAllCalls: {
+        name: string;
+        value: string;
+        options: CookieOptions;
+      }[] = [];
+
+      const { storage } = createStorageFromOptions(
+        {
+          cookieEncoding: "raw",
+          cookies: {
+            getAll: async () => [
+              { name: "storage-key", value: "value" },
+              { name: "storage-key.0", value: "chunk-0" },
+              { name: "unrelated", value: "ignored" },
+            ],
+            setAll: async (setCookies) => {
+              setAllCalls.push(...setCookies);
+            },
+          },
+        },
+        false,
+      );
+
+      await storage.removeItem("storage-key");
+
+      expect(setAllCalls).toEqual([
+        {
+          name: "storage-key",
+          value: "",
+          options: { ...DEFAULT_COOKIE_OPTIONS, maxAge: 0 },
+        },
+        {
+          name: "storage-key.0",
+          value: "",
+          options: { ...DEFAULT_COOKIE_OPTIONS, maxAge: 0 },
+        },
+      ]);
+    });
+
+    it("emits two Set-Cookies per chunk when domain is configured (with-domain + host-only)", async () => {
+      const setAllCalls: {
+        name: string;
+        value: string;
+        options: CookieOptions;
+      }[] = [];
+
+      const { storage } = createStorageFromOptions(
+        {
+          cookieEncoding: "raw",
+          cookieOptions: { domain: ".example.com" },
+          cookies: {
+            getAll: async () => [
+              { name: "storage-key", value: "value" },
+              { name: "storage-key.0", value: "chunk-0" },
+            ],
+            setAll: async (setCookies) => {
+              setAllCalls.push(...setCookies);
+            },
+          },
+        },
+        false,
+      );
+
+      await storage.removeItem("storage-key");
+
+      const withDomain = {
+        ...DEFAULT_COOKIE_OPTIONS,
+        domain: ".example.com",
+        maxAge: 0,
+      };
+      const hostOnly = { ...DEFAULT_COOKIE_OPTIONS, maxAge: 0 };
+
+      expect(setAllCalls).toEqual([
+        { name: "storage-key", value: "", options: withDomain },
+        { name: "storage-key.0", value: "", options: withDomain },
+        { name: "storage-key", value: "", options: hostOnly },
+        { name: "storage-key.0", value: "", options: hostOnly },
+      ]);
+    });
+
+    it("emits no Set-Cookie when there are no chunks to clear (with or without domain)", async () => {
+      const setAllCalls: unknown[] = [];
+
+      const { storage } = createStorageFromOptions(
+        {
+          cookieEncoding: "raw",
+          cookieOptions: { domain: ".example.com" },
+          cookies: {
+            getAll: async () => [{ name: "unrelated", value: "ignored" }],
+            setAll: async (setCookies) => {
+              setAllCalls.push(...setCookies);
+            },
+          },
+        },
+        false,
+      );
+
+      await storage.removeItem("storage-key");
+
+      expect(setAllCalls).toEqual([]);
+    });
+  });
+
+  describe("browser client setItem chunk-cleanup", () => {
+    it("clears stale chunks at both scopes when domain is configured", async () => {
+      const setAllCalls: {
+        name: string;
+        value: string;
+        options: CookieOptions;
+      }[] = [];
+
+      const { storage } = createStorageFromOptions(
+        {
+          cookieEncoding: "raw",
+          cookieOptions: { domain: ".example.com" },
+          cookies: {
+            getAll: async () => [
+              { name: "storage-key", value: "old-non-chunked" },
+              { name: "storage-key.4", value: "stale-chunk" },
+            ],
+            setAll: async (setCookies) => {
+              setAllCalls.push(...setCookies);
+            },
+          },
+        },
+        false,
+      );
+
+      await storage.setItem("storage-key", "new-value");
+
+      const withDomainRemove = {
+        ...DEFAULT_COOKIE_OPTIONS,
+        domain: ".example.com",
+        maxAge: 0,
+      };
+      const hostOnlyRemove = { ...DEFAULT_COOKIE_OPTIONS, maxAge: 0 };
+      const withDomainSet = {
+        ...DEFAULT_COOKIE_OPTIONS,
+        domain: ".example.com",
+      };
+
+      // Order: with-domain removes, then host-only removes, then the set.
+      expect(setAllCalls).toEqual([
+        { name: "storage-key.4", value: "", options: withDomainRemove },
+        { name: "storage-key.4", value: "", options: hostOnlyRemove },
+        { name: "storage-key", value: "new-value", options: withDomainSet },
+      ]);
+    });
+  });
+
+  describe("applyServerStorage", () => {
+    it("clears removed items at both scopes when domain is configured", async () => {
+      const setAllCalls: {
+        name: string;
+        value: string;
+        options: CookieOptions;
+      }[] = [];
+
+      const { storage, getAll, setAll, setItems, removedItems } =
+        createStorageFromOptions(
+          {
+            cookieEncoding: "raw",
+            cookieOptions: { domain: ".example.com" },
+            cookies: {
+              getAll: async () => [
+                { name: "remove-key", value: "old" },
+                { name: "remove-key.0", value: "old-chunk" },
+              ],
+              setAll: async (setCookies) => {
+                setAllCalls.push(...setCookies);
+              },
+            },
+          },
+          true,
+        );
+
+      await storage.removeItem("remove-key");
+      await applyServerStorage(
+        { getAll, setAll, setItems, removedItems },
+        {
+          cookieEncoding: "raw",
+          cookieOptions: { domain: ".example.com" },
+        },
+      );
+
+      const withDomain = {
+        ...DEFAULT_COOKIE_OPTIONS,
+        domain: ".example.com",
+        maxAge: 0,
+      };
+      const hostOnly = { ...DEFAULT_COOKIE_OPTIONS, maxAge: 0 };
+
+      expect(setAllCalls).toEqual([
+        { name: "remove-key", value: "", options: withDomain },
+        { name: "remove-key.0", value: "", options: withDomain },
+        { name: "remove-key", value: "", options: hostOnly },
+        { name: "remove-key.0", value: "", options: hostOnly },
+      ]);
+    });
+
+    it("does not emit host-only removes when no domain is configured (baseline)", async () => {
+      const setAllCalls: {
+        name: string;
+        value: string;
+        options: CookieOptions;
+      }[] = [];
+
+      const { storage, getAll, setAll, setItems, removedItems } =
+        createStorageFromOptions(
+          {
+            cookieEncoding: "raw",
+            cookies: {
+              getAll: async () => [{ name: "remove-key", value: "old" }],
+              setAll: async (setCookies) => {
+                setAllCalls.push(...setCookies);
+              },
+            },
+          },
+          true,
+        );
+
+      await storage.removeItem("remove-key");
+      await applyServerStorage(
+        { getAll, setAll, setItems, removedItems },
+        { cookieEncoding: "raw" },
+      );
+
+      expect(setAllCalls).toEqual([
+        {
+          name: "remove-key",
+          value: "",
+          options: { ...DEFAULT_COOKIE_OPTIONS, maxAge: 0 },
+        },
+      ]);
+    });
+  });
+});

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -285,12 +285,29 @@ export function createStorageFromOptions(
           delete removeCookieOptions.name;
           delete setCookieOptions.name;
 
+          // See removeItem below for the host-only also-clear rationale.
+          // Same logic applies here: when overwriting an existing session,
+          // stale chunks at a previous scope must be cleared at that scope.
+          const hostOnlyRemoveOptions = removeCookieOptions.domain
+            ? (() => {
+                const { domain: _domain, ...rest } = removeCookieOptions;
+                return rest;
+              })()
+            : null;
+
           const allToSet = [
             ...[...removeCookies].map((name) => ({
               name,
               value: "",
               options: removeCookieOptions,
             })),
+            ...(hostOnlyRemoveOptions
+              ? [...removeCookies].map((name) => ({
+                  name,
+                  value: "",
+                  options: hostOnlyRemoveOptions,
+                }))
+              : []),
             ...setCookies.map(({ name, value }) => ({
               name,
               value,
@@ -309,6 +326,10 @@ export function createStorageFromOptions(
             isChunkLike(name, key),
           );
 
+          if (removeCookies.length === 0) {
+            return;
+          }
+
           const removeCookieOptions = {
             ...DEFAULT_COOKIE_OPTIONS,
             ...options?.cookieOptions,
@@ -319,16 +340,31 @@ export function createStorageFromOptions(
           // options.cookieOptions leaks
           delete removeCookieOptions.name;
 
-          if (removeCookies.length > 0) {
-            await setAll(
-              removeCookies.map((name) => ({
+          const toSet = removeCookies.map((name) => ({
+            name,
+            value: "",
+            options: removeCookieOptions,
+          }));
+
+          // When a parent Domain is configured, also clear the host-only
+          // counterpart. Migrating host-only -> `.parent.tld` leaves the old
+          // host-only cookies behind; the browser returns both in the Cookie
+          // header and parsers may pick the stale one, resurrecting the
+          // session after signOut. A Set-Cookie clear for a scope the host
+          // doesn't own is silently ignored, so this is a no-op when there's
+          // nothing stale to clear.
+          if (removeCookieOptions.domain) {
+            const { domain: _domain, ...hostOnlyOptions } = removeCookieOptions;
+            toSet.push(
+              ...removeCookies.map((name) => ({
                 name,
                 value: "",
-                options: removeCookieOptions,
+                options: hostOnlyOptions,
               })),
-              {},
             );
           }
+
+          await setAll(toSet, {});
         },
       },
     };
@@ -498,6 +534,16 @@ export async function applyServerStorage(
   delete (removeCookieOptions as any).name;
   delete (setCookieOptions as any).name;
 
+  // See removeItem in createStorageFromOptions for the host-only also-clear
+  // rationale. Same logic on the server-side response path.
+  const hostOnlyRemoveOptions =
+    removeCookieOptions.domain && removeCookies.length > 0
+      ? (() => {
+          const { domain: _domain, ...rest } = removeCookieOptions;
+          return rest;
+        })()
+      : null;
+
   await setAll(
     [
       ...removeCookies.map((name) => ({
@@ -505,6 +551,13 @@ export async function applyServerStorage(
         value: "",
         options: removeCookieOptions,
       })),
+      ...(hostOnlyRemoveOptions
+        ? removeCookies.map((name) => ({
+            name,
+            value: "",
+            options: hostOnlyRemoveOptions,
+          }))
+        : []),
       ...setCookies.map(({ name, value }) => ({
         name,
         value,

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,4 +8,5 @@ export * from "./createBrowserClient";
 export * from "./createServerClient";
 export * from "./types";
 export * from "./utils";
+export { clearAuthCookiesAtScopes } from "./clearAuthCookiesAtScopes";
 export { warnIfUsingDeprecatedAuthHelpersPackage } from "./warnDeprecatedPackage";


### PR DESCRIPTION
## Summary

Fixes a stuck-session bug for users who change their cookie `Domain` in production (typically host-only to `.parent.tld`). After such a migration, `signOut` could not clear the stale host-only cookies, the browser kept returning both copies, and the session resurrected on the next read.

Reported on supabase/supabase-js#2392. No read-side fix is possible: `document.cookie` does not expose `Domain` to JS, so the fix has to be on the write side.

## What changed

- `removeItem`, `setItem` chunk cleanup, and `applyServerStorage`: when `cookieOptions.domain` is set, also emit a `Set-Cookie` clear with no `Domain` attribute. No change when `domain` is not configured.
- New exported helper `clearAuthCookiesAtScopes` for rarer multi-scope migrations (`.parent1` to `.parent2`, path changes). Idempotent; safe to over-call (browser ignores clears at scopes the host does not own).

## Behavior

Not breaking. Zero observable change for clients that do not set `cookieOptions.domain`. For clients that do, the extra `Set-Cookie` is a no-op unless a stale host-only cookie at the same name actually exists. Ship as minor (`feat` for the helper dominates the `fix` for the auto-clear).

## Tests

New `describe` block in `cookies.spec.ts` covering `removeItem`, `setItem` chunk cleanup, and `applyServerStorage` for both with-domain and baseline cases. New `clearAuthCookiesAtScopes.spec.ts` covering the helper.
