### PR TITLE
fix(release): pin npm to 11.5.2 so OIDC trusted publisher works

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,14 @@ jobs:
           node-version: 22
           registry-url: "https://registry.npmjs.org"
 
+      - name: Pin npm CLI (OIDC trusted publisher requires npm >= 11.5.1)
+        # actions/setup-node ships Node 22 with npm 10.9.x, which has no OIDC
+        # trusted-publisher code path. Without npm >= 11.5.1 the publish falls
+        # back to the .npmrc placeholder token written by setup-node and the
+        # registry returns 404. No NPM_TOKEN is configured on this repo by
+        # design — auth is OIDC only. Do not remove without restoring a token.
+        run: npm install -g npm@11.5.2
+
       - name: Determine version
         id: version
         env:


### PR DESCRIPTION
## Summary

- Re-adds an explicit npm install before the publish step so the workflow runs on **npm 11.5.2** (the version that supports OIDC trusted-publisher exchange) instead of Node 22's bundled npm 10.9.x.
- Adds a multi-line comment in the workflow explaining the dependency, so the line is not deleted again.

## Background

The release pipeline has been silently broken since #221 (May 12). That PR removed `corepack enable npm && corepack prepare npm@11 --activate` with the claim "no longer needed", but `actions/setup-node@v6.4.0` does **not** upgrade npm — Node 22 ships with npm 10.9.x.

npm only learned how to do OIDC trusted-publisher exchange in **11.5.1**. On npm 10, `npm publish --provenance` signs the provenance via sigstore (which works because it uses the GitHub OIDC token directly), then sends the bogus `.npmrc` placeholder `XXXXX-XXXXX-XXXXX-XXXXX` as the bearer token to the registry. The registry returns `404 Not Found - PUT https://registry.npmjs.org/@supabase%2fssr` (npm registry returns 404 for unauthenticated PUTs to avoid leaking which packages exist).

The repo has **no `NPM_TOKEN` secret** configured anywhere — by design, per #221's hardening posture. Auth is OIDC-only via the trusted-publisher binding on npmjs.com. Re-adding a token would weaken that posture, so the fix is to ensure the npm CLI is new enough to use OIDC.

## Why this went undetected

Between #221's merge (May 12) and #240's merge (June 4), every release run was for a `chore: update @supabase/supabase-js` commit. Those have no pending release-please PR, so the workflow's version-determination step took the `skip=true` branch and never attempted to publish. The first publish attempt on npm 10 — #240's merge on June 4 — failed with E404, as did the two release runs after it (#245, #244).

Failed runs:
- [27136548767](https://github.com/supabase/ssr/actions/runs/27136548767) — PR #244 ("release 0.11.0") merge, tried to publish `0.12.0-rc.118`
- [27008002122](https://github.com/supabase/ssr/actions/runs/27008002122) — PR #245 merge
- [26949675017](https://github.com/supabase/ssr/actions/runs/26949675017) — PR #240 merge, tried to publish `0.11.0-rc.117`

Last successful publish: `v0.10.3` on May 7 (run [25509681243](https://github.com/supabase/ssr/actions/runs/25509681243)), which ran on npm 11 via the corepack line that #221 removed.
