### PR TITLE
fix(cookies): keep domain-scoped deletion in name-keyed cookie stores

### DIFF
--- a/src/cookies.spec.ts
+++ b/src/cookies.spec.ts
@@ -1527,6 +1527,45 @@ describe("host-only also-clear when cookieOptions.domain is set", () => {
       expect(store.get("storage-key")?.domain).toBe(".example.com");
       expect(store.get("storage-key.0")?.domain).toBe(".example.com");
     });
+
+    it("keeps the domain-scoped deletion through applyServerStorage", async () => {
+      // same store semantics as above, but through the server path that
+      // powers signOut() in Next.js Route Handlers and Server Actions
+      const store = new Map<string, CookieOptions>();
+
+      const { storage, getAll, setAll, setItems, removedItems } =
+        createStorageFromOptions(
+          {
+            cookieEncoding: "raw",
+            cookieOptions: { domain: ".example.com" },
+            cookies: {
+              getAll: async () => [
+                { name: "remove-key", value: "value" },
+                { name: "remove-key.0", value: "chunk-0" },
+              ],
+              setAll: async (setCookies) => {
+                // model @edge-runtime/cookies: last write for a name wins
+                setCookies.forEach(({ name, options }) =>
+                  store.set(name, options),
+                );
+              },
+            },
+          },
+          true,
+        );
+
+      await storage.removeItem("remove-key");
+      await applyServerStorage(
+        { getAll, setAll, setItems, removedItems },
+        {
+          cookieEncoding: "raw",
+          cookieOptions: { domain: ".example.com" },
+        },
+      );
+
+      expect(store.get("remove-key")?.domain).toBe(".example.com");
+      expect(store.get("remove-key.0")?.domain).toBe(".example.com");
+    });
   });
 
   describe("browser client setItem chunk-cleanup", () => {

--- a/src/cookies.spec.ts
+++ b/src/cookies.spec.ts
@@ -1428,7 +1428,7 @@ describe("host-only also-clear when cookieOptions.domain is set", () => {
       ]);
     });
 
-    it("emits two Set-Cookies per chunk when domain is configured (with-domain + host-only)", async () => {
+    it("emits two Set-Cookies per chunk when domain is configured (host-only + with-domain)", async () => {
       const setAllCalls: {
         name: string;
         value: string;
@@ -1462,10 +1462,10 @@ describe("host-only also-clear when cookieOptions.domain is set", () => {
       const hostOnly = { ...DEFAULT_COOKIE_OPTIONS, maxAge: 0 };
 
       expect(setAllCalls).toEqual([
-        { name: "storage-key", value: "", options: withDomain },
-        { name: "storage-key.0", value: "", options: withDomain },
         { name: "storage-key", value: "", options: hostOnly },
         { name: "storage-key.0", value: "", options: hostOnly },
+        { name: "storage-key", value: "", options: withDomain },
+        { name: "storage-key.0", value: "", options: withDomain },
       ]);
     });
 
@@ -1489,6 +1489,43 @@ describe("host-only also-clear when cookieOptions.domain is set", () => {
       await storage.removeItem("storage-key");
 
       expect(setAllCalls).toEqual([]);
+    });
+  });
+
+  describe("name-keyed cookie store (Next.js ResponseCookies semantics)", () => {
+    // Next.js backs cookies() / NextResponse.cookies with a store keyed by
+    // cookie name only, so a later set() for the same name overwrites the
+    // earlier one when it rewrites the Set-Cookie headers. When a domain is
+    // configured, the best-effort host-only clear must not displace the
+    // domain-scoped deletion that actually matches the cookies this library
+    // set, otherwise the session cookie is never removed on signOut (#256).
+    it("keeps the domain-scoped deletion after a same-name host-only clear", async () => {
+      const store = new Map<string, CookieOptions>();
+
+      const { storage } = createStorageFromOptions(
+        {
+          cookieEncoding: "raw",
+          cookieOptions: { domain: ".example.com" },
+          cookies: {
+            getAll: async () => [
+              { name: "storage-key", value: "value" },
+              { name: "storage-key.0", value: "chunk-0" },
+            ],
+            setAll: async (setCookies) => {
+              // model @edge-runtime/cookies: last write for a name wins
+              setCookies.forEach(({ name, options }) =>
+                store.set(name, options),
+              );
+            },
+          },
+        },
+        false,
+      );
+
+      await storage.removeItem("storage-key");
+
+      expect(store.get("storage-key")?.domain).toBe(".example.com");
+      expect(store.get("storage-key.0")?.domain).toBe(".example.com");
     });
   });
 
@@ -1530,10 +1567,10 @@ describe("host-only also-clear when cookieOptions.domain is set", () => {
         domain: ".example.com",
       };
 
-      // Order: with-domain removes, then host-only removes, then the set.
+      // Order: host-only removes, then with-domain removes, then the set.
       expect(setAllCalls).toEqual([
-        { name: "storage-key.4", value: "", options: withDomainRemove },
         { name: "storage-key.4", value: "", options: hostOnlyRemove },
+        { name: "storage-key.4", value: "", options: withDomainRemove },
         { name: "storage-key", value: "new-value", options: withDomainSet },
       ]);
     });
@@ -1582,10 +1619,10 @@ describe("host-only also-clear when cookieOptions.domain is set", () => {
       const hostOnly = { ...DEFAULT_COOKIE_OPTIONS, maxAge: 0 };
 
       expect(setAllCalls).toEqual([
-        { name: "remove-key", value: "", options: withDomain },
-        { name: "remove-key.0", value: "", options: withDomain },
         { name: "remove-key", value: "", options: hostOnly },
         { name: "remove-key.0", value: "", options: hostOnly },
+        { name: "remove-key", value: "", options: withDomain },
+        { name: "remove-key.0", value: "", options: withDomain },
       ]);
     });
 

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -296,11 +296,6 @@ export function createStorageFromOptions(
             : null;
 
           const allToSet = [
-            ...[...removeCookies].map((name) => ({
-              name,
-              value: "",
-              options: removeCookieOptions,
-            })),
             ...(hostOnlyRemoveOptions
               ? [...removeCookies].map((name) => ({
                   name,
@@ -308,6 +303,11 @@ export function createStorageFromOptions(
                   options: hostOnlyRemoveOptions,
                 }))
               : []),
+            ...[...removeCookies].map((name) => ({
+              name,
+              value: "",
+              options: removeCookieOptions,
+            })),
             ...setCookies.map(({ name, value }) => ({
               name,
               value,
@@ -340,12 +340,6 @@ export function createStorageFromOptions(
           // options.cookieOptions leaks
           delete removeCookieOptions.name;
 
-          const toSet = removeCookies.map((name) => ({
-            name,
-            value: "",
-            options: removeCookieOptions,
-          }));
-
           // When a parent Domain is configured, also clear the host-only
           // counterpart. Migrating host-only -> `.parent.tld` leaves the old
           // host-only cookies behind; the browser returns both in the Cookie
@@ -353,16 +347,35 @@ export function createStorageFromOptions(
           // session after signOut. A Set-Cookie clear for a scope the host
           // doesn't own is silently ignored, so this is a no-op when there's
           // nothing stale to clear.
-          if (removeCookieOptions.domain) {
-            const { domain: _domain, ...hostOnlyOptions } = removeCookieOptions;
-            toSet.push(
-              ...removeCookies.map((name) => ({
-                name,
-                value: "",
-                options: hostOnlyOptions,
-              })),
-            );
-          }
+          //
+          // The host-only clear is emitted *before* the domain-scoped one so
+          // that cookie stores keyed by name only (e.g. Next.js
+          // ResponseCookies) keep the domain-scoped deletion -- the one that
+          // matches the cookies this library set -- instead of letting the
+          // best-effort host-only clear overwrite it, which would leave the
+          // session cookie undeleted (#256). Stores that emit a Set-Cookie
+          // per entry still receive both.
+          const hostOnlyOptions = removeCookieOptions.domain
+            ? (() => {
+                const { domain: _domain, ...rest } = removeCookieOptions;
+                return rest;
+              })()
+            : null;
+
+          const toSet = [
+            ...(hostOnlyOptions
+              ? removeCookies.map((name) => ({
+                  name,
+                  value: "",
+                  options: hostOnlyOptions,
+                }))
+              : []),
+            ...removeCookies.map((name) => ({
+              name,
+              value: "",
+              options: removeCookieOptions,
+            })),
+          ];
 
           await setAll(toSet, {});
         },
@@ -559,11 +572,6 @@ export async function applyServerStorage(
 
   await setAll(
     [
-      ...removeCookiesToWrite.map((name) => ({
-        name,
-        value: "",
-        options: removeCookieOptions,
-      })),
       ...(hostOnlyRemoveOptions
         ? removeCookiesToWrite.map((name) => ({
             name,
@@ -571,6 +579,11 @@ export async function applyServerStorage(
             options: hostOnlyRemoveOptions,
           }))
         : []),
+      ...removeCookiesToWrite.map((name) => ({
+        name,
+        value: "",
+        options: removeCookieOptions,
+      })),
       ...setCookiesToWrite.map(({ name, value }) => ({
         name,
         value,


### PR DESCRIPTION
since #240 added the host-only also-clear, `removeItem`, the `setItem` chunk cleanup and `applyServerStorage` emit two entries for the same cookie name when a domain is configured — the domain clear first, then the host-only one. next.js backs its cookie store with a map keyed by name only (`ResponseCookies` from `@edge-runtime/cookies`), so the second host-only entry (no `Domain`) overwrites the first and only that reaches the browser. browsers match cookies by (name, domain, path), so the domain-scoped session cookie the library itself set never gets deleted and `signOut()` leaves the session stuck for any project that sets `cookieOptions.domain`.

this flips the order so the host-only clear comes first and the domain clear last. name-keyed stores keep the domain deletion (the one that matches what we set) and only drop the best-effort host-only cleanup; adapters that emit a Set-Cookie per entry still get both. no behaviour change when no domain is configured.

the tests added in #240 asserted the payload order, so they passed even though the collapse happens one layer down in the cookie store — i added a test that runs `removeItem` through a name-keyed store and checks the surviving deletion still carries the domain (fails on the old order), and updated the three existing order assertions to match.

fixes #256