### PR TITLE
docs: align getSession/getUser/getClaims guidance with docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,22 +35,8 @@ Please refer to the [official server-side rendering guides](https://supabase.com
 
 ## Known patterns and limitations
 
-### `getSession()` vs `getUser()` vs `getClaims()`
-
-`getSession()` returns the session directly from cookies — no network call is
-made. The user object it contains is **not verified by the Auth server** and
-must not be used for authorization decisions; a malicious client could craft a
-cookie with a spoofed user ID. **Do not use `getSession()` for authorization decisions.**
-
-`getClaims()` validates the access token either locally (using the project's
-JWKS endpoint for asymmetric keys) or by calling the Auth server, and returns
-the verified JWT claims. Use it when you need to gate access to resources but
-don't need a fresh user record from the database.
-
-`getUser()` contacts the Supabase Auth server on every call and returns the
-most up-to-date user record, including any changes made since the token was
-issued. Use it when you need fresh user data (e.g. checking current roles,
-email, or whether the session is still active server-side).
+For guidance on choosing between `getSession()`, `getUser()`, and `getClaims()`,
+see the [official server-side rendering guides](https://supabase.com/docs/guides/auth/server-side).
 
 ### Concurrent requests with the same expired session
 

--- a/src/createServerClient.ts
+++ b/src/createServerClient.ts
@@ -79,9 +79,10 @@ export function createServerClient<
  * **Session initialization.**
  *
  * This client uses lazy session initialization (`skipAutoInitialize: true`).
- * The session is not loaded until the first call to `getSession()` or
- * `getUser()`. Token refreshes write the updated session back to cookies via
- * the `setAll` handler.
+ * The session is not loaded until the first call to `getSession()`,
+ * `getUser()`, or `getClaims()` (which calls `getSession()` internally when
+ * no explicit JWT is passed). Token refreshes write the updated session back
+ * to cookies via the `setAll` handler.
  *
  * @param supabaseUrl The URL of the Supabase project.
  * @param supabaseKey The `anon` API key of the Supabase project.

--- a/src/types.ts
+++ b/src/types.ts
@@ -105,11 +105,11 @@ export type CookieMethodsServer = {
    * Called by the Supabase Client to write cookies to the response after a
    * token refresh or auth state change.
    *
-   * **IMPORTANT:** Call `await supabase.auth.getSession()` (or `getUser()`)
-   * early in your request handler — before any response is generated. If a
-   * token refresh completes after the HTTP response has already been committed,
-   * the updated session cannot be written here and will be lost, causing the
-   * next request to refresh again.
+   * **IMPORTANT:** Call `await supabase.auth.getClaims()` (or `getSession()`/
+   * `getUser()`) early in your request handler — before any response is
+   * generated. If a token refresh completes after the HTTP response has
+   * already been committed, the updated session cannot be written here and
+   * will be lost, causing the next request to refresh again.
    *
    * **CDN and reverse proxy caching.**
    *
@@ -118,13 +118,8 @@ export type CookieMethodsServer = {
    * set `Cache-Control: private, no-store` on routes that handle authentication
    * (typically your middleware) to prevent these responses from being cached.
    *
-   * **`getSession()` vs `getUser()`.**
-   *
-   * `getSession()` returns the session directly from cookies without contacting
-   * the Supabase Auth server. The user object it contains is therefore
-   * **not verified** and should not be used for authorization decisions.
-   * Use `getUser()` when you need a verified user identity — it contacts the
-   * Auth server on every call to validate the token.
+   * See the [official server-side rendering guides](https://supabase.com/docs/guides/auth/server-side)
+   * for guidance on choosing between `getSession()`, `getUser()`, and `getClaims()`.
    */
   setAll?: SetAllCookies;
 };


### PR DESCRIPTION
Remove the duplicated auth-method explanation from README (point to the official SSR guides instead) and fix stale JSDoc that omitted getClaims() as the recommended default and as a lazy-init trigger.