### PR TITLE
docs: set up typedoc

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,55 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '22'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build docs (HTML + spec.json)
+        run: pnpm run docs
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: ./api-docs
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '22'
+          node-version: "22"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /dist
 /coverage
 /node_modules
+/api-docs
 /*.tgz

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "sideEffects": false,
   "scripts": {
     "build": "tsc && tsc -p tsconfig.main.json",
+    "docs": "typedoc",
     "test": "vitest"
   },
   "repository": {
@@ -39,6 +40,7 @@
     "@types/node": "^24.3.0",
     "eslint": "^8.57.0",
     "prettier": "^3.2.5",
+    "typedoc": "^0.28.19",
     "typescript": "^5.4.5",
     "typescript-eslint": "^7.10.0",
     "vitest": "^4.1.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       prettier:
         specifier: ^3.2.5
         version: 3.8.3
+      typedoc:
+        specifier: ^0.28.19
+        version: 0.28.20(typescript@5.9.3)
       typescript:
         specifier: ^5.4.5
         version: 5.9.3
@@ -35,7 +38,7 @@ importers:
         version: 7.18.0(eslint@8.57.1)(typescript@5.9.3)
       vitest:
         specifier: ^4.1.0
-        version: 4.1.8(@types/node@24.13.1)(vite@8.0.16(@types/node@24.13.1))
+        version: 4.1.8(@types/node@24.13.1)(vite@8.0.16(@types/node@24.13.1)(yaml@2.9.0))
 
 packages:
 
@@ -69,6 +72,9 @@ packages:
   '@eslint/js@9.39.4':
     resolution: {integrity: sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@gerrit0/mini-shiki@3.23.0':
+    resolution: {integrity: sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==}
 
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
@@ -205,6 +211,21 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
+  '@shikijs/engine-oniguruma@3.23.0':
+    resolution: {integrity: sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==}
+
+  '@shikijs/langs@3.23.0':
+    resolution: {integrity: sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==}
+
+  '@shikijs/themes@3.23.0':
+    resolution: {integrity: sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==}
+
+  '@shikijs/types@3.23.0':
+    resolution: {integrity: sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -247,8 +268,14 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
   '@types/node@24.13.1':
     resolution: {integrity: sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@typescript-eslint/eslint-plugin@7.18.0':
     resolution: {integrity: sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==}
@@ -375,11 +402,19 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   brace-expansion@1.1.15:
     resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
 
   brace-expansion@2.1.1:
     resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
+
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -441,6 +476,10 @@ packages:
   doctrine@3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
 
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
@@ -705,6 +744,9 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  linkify-it@5.0.2:
+    resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
+
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -712,8 +754,18 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  lunr@2.3.9:
+    resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  markdown-it@14.3.0:
+    resolution: {integrity: sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==}
+    hasBin: true
+
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -722,6 +774,10 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
 
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
@@ -806,6 +862,10 @@ packages:
     resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
     engines: {node: '>=14'}
     hasBin: true
+
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -916,6 +976,13 @@ packages:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
     engines: {node: '>=10'}
 
+  typedoc@0.28.20:
+    resolution: {integrity: sha512-uSKqkh8Cr48vllnEy+jdaAgOeR6Y+QCBW7usgUsKj7gJEfR7stw9U/fE49LBnj2tPRKPY0c0EBJSWe9Appmplg==}
+    engines: {node: '>= 18', pnpm: '>= 10'}
+    hasBin: true
+    peerDependencies:
+      typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x
+
   typescript-eslint@7.18.0:
     resolution: {integrity: sha512-PonBkP603E3tt05lDkbOMyaxJjvKqQrXsnow72sVeOFINDE/qNmnnd+f9b4N+U7W6MXnnYyrhtmF2t08QWwUbA==}
     engines: {node: ^18.18.0 || >=20.0.0}
@@ -930,6 +997,9 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
@@ -1038,6 +1108,11 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -1084,6 +1159,14 @@ snapshots:
   '@eslint/js@8.57.1': {}
 
   '@eslint/js@9.39.4': {}
+
+  '@gerrit0/mini-shiki@3.23.0':
+    dependencies:
+      '@shikijs/engine-oniguruma': 3.23.0
+      '@shikijs/langs': 3.23.0
+      '@shikijs/themes': 3.23.0
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
 
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
@@ -1171,6 +1254,26 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
+  '@shikijs/engine-oniguruma@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+
+  '@shikijs/themes@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+
+  '@shikijs/types@3.23.0':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/vscode-textmate@10.0.2': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@supabase/auth-js@2.110.6':
@@ -1219,9 +1322,15 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/node@24.13.1':
     dependencies:
       undici-types: 7.18.2
+
+  '@types/unist@3.0.3': {}
 
   '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
@@ -1315,13 +1424,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@24.13.1))':
+  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@24.13.1)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.16(@types/node@24.13.1)
+      vite: 8.0.16(@types/node@24.13.1)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.8':
     dependencies:
@@ -1374,6 +1483,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   brace-expansion@1.1.15:
     dependencies:
       balanced-match: 1.0.2
@@ -1382,6 +1493,10 @@ snapshots:
   brace-expansion@2.1.1:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.7:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -1429,6 +1544,8 @@ snapshots:
   doctrine@3.0.0:
     dependencies:
       esutils: 2.0.3
+
+  entities@4.5.0: {}
 
   es-module-lexer@2.1.0: {}
 
@@ -1688,15 +1805,32 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  linkify-it@5.0.2:
+    dependencies:
+      uc.micro: 2.1.0
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
 
   lodash.merge@4.6.2: {}
 
+  lunr@2.3.9: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  markdown-it@14.3.0:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.2
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+
+  mdurl@2.0.0: {}
 
   merge2@1.4.1: {}
 
@@ -1704,6 +1838,10 @@ snapshots:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.2
+
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.7
 
   minimatch@3.1.5:
     dependencies:
@@ -1771,6 +1909,8 @@ snapshots:
   prelude-ls@1.2.1: {}
 
   prettier@3.8.3: {}
+
+  punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
 
@@ -1866,6 +2006,15 @@ snapshots:
 
   type-fest@0.20.2: {}
 
+  typedoc@0.28.20(typescript@5.9.3):
+    dependencies:
+      '@gerrit0/mini-shiki': 3.23.0
+      lunr: 2.3.9
+      markdown-it: 14.3.0
+      minimatch: 10.2.5
+      typescript: 5.9.3
+      yaml: 2.9.0
+
   typescript-eslint@7.18.0(eslint@8.57.1)(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
@@ -1879,13 +2028,15 @@ snapshots:
 
   typescript@5.9.3: {}
 
+  uc.micro@2.1.0: {}
+
   undici-types@7.18.2: {}
 
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
 
-  vite@8.0.16(@types/node@24.13.1):
+  vite@8.0.16(@types/node@24.13.1)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -1895,11 +2046,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.13.1
       fsevents: 2.3.3
+      yaml: 2.9.0
 
-  vitest@4.1.8(@types/node@24.13.1)(vite@8.0.16(@types/node@24.13.1)):
+  vitest@4.1.8(@types/node@24.13.1)(vite@8.0.16(@types/node@24.13.1)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@24.13.1))
+      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@24.13.1)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -1916,7 +2068,7 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.0.16(@types/node@24.13.1)
+      vite: 8.0.16(@types/node@24.13.1)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.13.1
@@ -1935,5 +2087,7 @@ snapshots:
   word-wrap@1.2.5: {}
 
   wrappy@1.0.2: {}
+
+  yaml@2.9.0: {}
 
   yocto-queue@0.1.0: {}

--- a/src/clearAuthCookiesAtScopes.ts
+++ b/src/clearAuthCookiesAtScopes.ts
@@ -1,5 +1,5 @@
-import type { CookieOptions, GetAllCookies, SetAllCookies } from './types'
-import { DEFAULT_COOKIE_OPTIONS, isChunkLike } from './utils'
+import type { CookieOptions, GetAllCookies, SetAllCookies } from "./types";
+import { DEFAULT_COOKIE_OPTIONS, isChunkLike } from "./utils";
 
 /**
  * One-shot helper to clear Supabase auth cookies at one or more explicit
@@ -38,24 +38,24 @@ import { DEFAULT_COOKIE_OPTIONS, isChunkLike } from './utils'
  * @category Cookies
  */
 export async function clearAuthCookiesAtScopes(input: {
-  getAll: (keyHints: string[]) => ReturnType<GetAllCookies>
-  setAll: SetAllCookies
-  storageKey: string
-  scopes: Array<Partial<CookieOptions>>
+  getAll: (keyHints: string[]) => ReturnType<GetAllCookies>;
+  setAll: SetAllCookies;
+  storageKey: string;
+  scopes: Array<Partial<CookieOptions>>;
 }): Promise<void> {
-  const { getAll, setAll, storageKey, scopes } = input
+  const { getAll, setAll, storageKey, scopes } = input;
 
   if (scopes.length === 0) {
-    return
+    return;
   }
 
-  const allCookies = (await getAll([storageKey])) ?? []
+  const allCookies = (await getAll([storageKey])) ?? [];
   const chunkNames = allCookies
     .map(({ name }) => name)
-    .filter((name) => isChunkLike(name, storageKey))
+    .filter((name) => isChunkLike(name, storageKey));
 
   if (chunkNames.length === 0) {
-    return
+    return;
   }
 
   const toSet = scopes.flatMap((scope) => {
@@ -63,17 +63,17 @@ export async function clearAuthCookiesAtScopes(input: {
       ...DEFAULT_COOKIE_OPTIONS,
       ...scope,
       maxAge: 0,
-    }
+    };
 
     // Same NextJS cookieStore guard as createStorageFromOptions.
-    delete (cookieOptions as { name?: string }).name
+    delete (cookieOptions as { name?: string }).name;
 
     return chunkNames.map((name) => ({
       name,
-      value: '',
+      value: "",
       options: cookieOptions,
-    }))
-  })
+    }));
+  });
 
-  await setAll(toSet, {})
+  await setAll(toSet, {});
 }

--- a/src/clearAuthCookiesAtScopes.ts
+++ b/src/clearAuthCookiesAtScopes.ts
@@ -1,5 +1,5 @@
-import { DEFAULT_COOKIE_OPTIONS, isChunkLike } from "./utils";
-import type { CookieOptions, GetAllCookies, SetAllCookies } from "./types";
+import type { CookieOptions, GetAllCookies, SetAllCookies } from './types'
+import { DEFAULT_COOKIE_OPTIONS, isChunkLike } from './utils'
 
 /**
  * One-shot helper to clear Supabase auth cookies at one or more explicit
@@ -34,26 +34,28 @@ import type { CookieOptions, GetAllCookies, SetAllCookies } from "./types";
  *     storageKey: 'sb-<project-ref>-auth-token',
  *     scopes: [{ path: '/app' }],
  *   });
+ *
+ * @category Cookies
  */
 export async function clearAuthCookiesAtScopes(input: {
-  getAll: (keyHints: string[]) => ReturnType<GetAllCookies>;
-  setAll: SetAllCookies;
-  storageKey: string;
-  scopes: Array<Partial<CookieOptions>>;
+  getAll: (keyHints: string[]) => ReturnType<GetAllCookies>
+  setAll: SetAllCookies
+  storageKey: string
+  scopes: Array<Partial<CookieOptions>>
 }): Promise<void> {
-  const { getAll, setAll, storageKey, scopes } = input;
+  const { getAll, setAll, storageKey, scopes } = input
 
   if (scopes.length === 0) {
-    return;
+    return
   }
 
-  const allCookies = (await getAll([storageKey])) ?? [];
+  const allCookies = (await getAll([storageKey])) ?? []
   const chunkNames = allCookies
     .map(({ name }) => name)
-    .filter((name) => isChunkLike(name, storageKey));
+    .filter((name) => isChunkLike(name, storageKey))
 
   if (chunkNames.length === 0) {
-    return;
+    return
   }
 
   const toSet = scopes.flatMap((scope) => {
@@ -61,17 +63,17 @@ export async function clearAuthCookiesAtScopes(input: {
       ...DEFAULT_COOKIE_OPTIONS,
       ...scope,
       maxAge: 0,
-    };
+    }
 
     // Same NextJS cookieStore guard as createStorageFromOptions.
-    delete (cookieOptions as { name?: string }).name;
+    delete (cookieOptions as { name?: string }).name
 
     return chunkNames.map((name) => ({
       name,
-      value: "",
+      value: '',
       options: cookieOptions,
-    }));
-  });
+    }))
+  })
 
-  await setAll(toSet, {});
+  await setAll(toSet, {})
 }

--- a/src/createBrowserClient.ts
+++ b/src/createBrowserClient.ts
@@ -1,22 +1,16 @@
-import {
-  createClient,
-  SupabaseClient,
-  SupabaseClientOptions,
-} from "@supabase/supabase-js";
+import { createClient, SupabaseClient, SupabaseClientOptions } from '@supabase/supabase-js'
 
-import { VERSION } from "./version";
-import { isBrowser } from "./utils";
-
+import { createStorageFromOptions } from './cookies'
 import type {
   CookieMethodsBrowser,
   CookieMethodsBrowserDeprecated,
   CookieOptionsWithName,
-} from "./types";
+} from './types'
+import { isBrowser } from './utils'
+import { VERSION } from './version'
+import { warnIfUsingDeprecatedAuthHelpersPackage } from './warnDeprecatedPackage'
 
-import { createStorageFromOptions } from "./cookies";
-import { warnIfUsingDeprecatedAuthHelpersPackage } from "./warnDeprecatedPackage";
-
-let cachedBrowserClient: SupabaseClient<any, any, any> | undefined;
+let cachedBrowserClient: SupabaseClient<any, any, any> | undefined
 
 /**
  * Creates a Supabase Client for use in a browser environment.
@@ -34,23 +28,25 @@ let cachedBrowserClient: SupabaseClient<any, any, any> | undefined;
  * @param supabaseUrl The URL of the Supabase project.
  * @param supabaseKey The `anon` API key of the Supabase project.
  * @param options Various configuration options.
+ *
+ * @category Clients
  */
 export function createBrowserClient<
   Database = any,
-  SchemaName extends string & keyof Omit<Database, "__InternalSupabase"> =
-    "public" extends keyof Omit<Database, "__InternalSupabase">
-      ? "public"
-      : string & keyof Omit<Database, "__InternalSupabase">,
+  SchemaName extends string & keyof Omit<Database, '__InternalSupabase'> =
+    'public' extends keyof Omit<Database, '__InternalSupabase'>
+      ? 'public'
+      : string & keyof Omit<Database, '__InternalSupabase'>,
 >(
   supabaseUrl: string,
   supabaseKey: string,
   options?: SupabaseClientOptions<SchemaName> & {
-    cookies?: CookieMethodsBrowser;
-    cookieOptions?: CookieOptionsWithName;
-    cookieEncoding?: "raw" | "base64url";
-    isSingleton?: boolean;
-  },
-): SupabaseClient<Database, SchemaName>;
+    cookies?: CookieMethodsBrowser
+    cookieOptions?: CookieOptionsWithName
+    cookieEncoding?: 'raw' | 'base64url'
+    isSingleton?: boolean
+  }
+): SupabaseClient<Database, SchemaName>
 
 /**
  * @deprecated Please specify `getAll` and `setAll` cookie methods instead of
@@ -59,61 +55,60 @@ export function createBrowserClient<
  */
 export function createBrowserClient<
   Database = any,
-  SchemaName extends string & keyof Omit<Database, "__InternalSupabase"> =
-    "public" extends keyof Omit<Database, "__InternalSupabase">
-      ? "public"
-      : string & keyof Omit<Database, "__InternalSupabase">,
+  SchemaName extends string & keyof Omit<Database, '__InternalSupabase'> =
+    'public' extends keyof Omit<Database, '__InternalSupabase'>
+      ? 'public'
+      : string & keyof Omit<Database, '__InternalSupabase'>,
 >(
   supabaseUrl: string,
   supabaseKey: string,
   options?: SupabaseClientOptions<SchemaName> & {
-    cookies: CookieMethodsBrowserDeprecated;
-    cookieOptions?: CookieOptionsWithName;
-    cookieEncoding?: "raw" | "base64url";
-    isSingleton?: boolean;
-  },
-): SupabaseClient<Database, SchemaName>;
+    cookies: CookieMethodsBrowserDeprecated
+    cookieOptions?: CookieOptionsWithName
+    cookieEncoding?: 'raw' | 'base64url'
+    isSingleton?: boolean
+  }
+): SupabaseClient<Database, SchemaName>
 
 export function createBrowserClient<
   Database = any,
-  SchemaName extends string & keyof Omit<Database, "__InternalSupabase"> =
-    "public" extends keyof Omit<Database, "__InternalSupabase">
-      ? "public"
-      : string & keyof Omit<Database, "__InternalSupabase">,
+  SchemaName extends string & keyof Omit<Database, '__InternalSupabase'> =
+    'public' extends keyof Omit<Database, '__InternalSupabase'>
+      ? 'public'
+      : string & keyof Omit<Database, '__InternalSupabase'>,
 >(
   supabaseUrl: string,
   supabaseKey: string,
   options?: SupabaseClientOptions<SchemaName> & {
-    cookies?: CookieMethodsBrowser | CookieMethodsBrowserDeprecated;
-    cookieOptions?: CookieOptionsWithName;
-    cookieEncoding?: "raw" | "base64url";
-    isSingleton?: boolean;
-  },
+    cookies?: CookieMethodsBrowser | CookieMethodsBrowserDeprecated
+    cookieOptions?: CookieOptionsWithName
+    cookieEncoding?: 'raw' | 'base64url'
+    isSingleton?: boolean
+  }
 ): SupabaseClient<Database, SchemaName> {
-  warnIfUsingDeprecatedAuthHelpersPackage();
+  warnIfUsingDeprecatedAuthHelpersPackage()
 
   // singleton client is created only if isSingleton is set to true, or if isSingleton is not defined and we detect a browser
   const shouldUseSingleton =
-    options?.isSingleton === true ||
-    ((!options || !("isSingleton" in options)) && isBrowser());
+    options?.isSingleton === true || ((!options || !('isSingleton' in options)) && isBrowser())
 
   if (shouldUseSingleton && cachedBrowserClient) {
-    return cachedBrowserClient;
+    return cachedBrowserClient
   }
 
   if (!supabaseUrl || !supabaseKey) {
     throw new Error(
-      `@supabase/ssr: Your project's URL and API key are required to create a Supabase client!\n\nCheck your Supabase project's API settings to find these values\n\nhttps://supabase.com/dashboard/project/_/settings/api`,
-    );
+      `@supabase/ssr: Your project's URL and API key are required to create a Supabase client!\n\nCheck your Supabase project's API settings to find these values\n\nhttps://supabase.com/dashboard/project/_/settings/api`
+    )
   }
 
   const { storage } = createStorageFromOptions(
     {
       ...options,
-      cookieEncoding: options?.cookieEncoding ?? "base64url",
+      cookieEncoding: options?.cookieEncoding ?? 'base64url',
     },
-    false,
-  );
+    false
+  )
 
   const client = createClient<Database, SchemaName>(supabaseUrl, supabaseKey, {
     // TODO: resolve type error
@@ -122,32 +117,30 @@ export function createBrowserClient<
       ...options?.global,
       headers: {
         ...options?.global?.headers,
-        "X-Client-Info": `supabase-ssr/${VERSION} createBrowserClient`,
+        'X-Client-Info': `supabase-ssr/${VERSION} createBrowserClient`,
       },
     },
     auth: {
       ...options?.auth,
-      ...(options?.cookieOptions?.name
-        ? { storageKey: options.cookieOptions.name }
-        : null),
-      flowType: "pkce",
+      ...(options?.cookieOptions?.name ? { storageKey: options.cookieOptions.name } : null),
+      flowType: 'pkce',
       autoRefreshToken: options?.auth?.autoRefreshToken ?? isBrowser(),
       detectSessionInUrl: options?.auth?.detectSessionInUrl ?? isBrowser(),
       persistSession: options?.auth?.persistSession ?? true,
       storage,
       ...(options?.cookies &&
-      "encode" in options.cookies &&
-      options.cookies.encode === "tokens-only"
+      'encode' in options.cookies &&
+      options.cookies.encode === 'tokens-only'
         ? {
             userStorage: options?.auth?.userStorage ?? window.localStorage,
           }
         : null),
     },
-  });
+  })
 
   if (shouldUseSingleton) {
-    cachedBrowserClient = client;
+    cachedBrowserClient = client
   }
 
-  return client;
+  return client
 }

--- a/src/createBrowserClient.ts
+++ b/src/createBrowserClient.ts
@@ -1,16 +1,20 @@
-import { createClient, SupabaseClient, SupabaseClientOptions } from '@supabase/supabase-js'
+import {
+  createClient,
+  SupabaseClient,
+  SupabaseClientOptions,
+} from "@supabase/supabase-js";
 
-import { createStorageFromOptions } from './cookies'
+import { createStorageFromOptions } from "./cookies";
 import type {
   CookieMethodsBrowser,
   CookieMethodsBrowserDeprecated,
   CookieOptionsWithName,
-} from './types'
-import { isBrowser } from './utils'
-import { VERSION } from './version'
-import { warnIfUsingDeprecatedAuthHelpersPackage } from './warnDeprecatedPackage'
+} from "./types";
+import { isBrowser } from "./utils";
+import { VERSION } from "./version";
+import { warnIfUsingDeprecatedAuthHelpersPackage } from "./warnDeprecatedPackage";
 
-let cachedBrowserClient: SupabaseClient<any, any, any> | undefined
+let cachedBrowserClient: SupabaseClient<any, any, any> | undefined;
 
 /**
  * Creates a Supabase Client for use in a browser environment.
@@ -33,20 +37,20 @@ let cachedBrowserClient: SupabaseClient<any, any, any> | undefined
  */
 export function createBrowserClient<
   Database = any,
-  SchemaName extends string & keyof Omit<Database, '__InternalSupabase'> =
-    'public' extends keyof Omit<Database, '__InternalSupabase'>
-      ? 'public'
-      : string & keyof Omit<Database, '__InternalSupabase'>,
+  SchemaName extends string & keyof Omit<Database, "__InternalSupabase"> =
+    "public" extends keyof Omit<Database, "__InternalSupabase">
+      ? "public"
+      : string & keyof Omit<Database, "__InternalSupabase">,
 >(
   supabaseUrl: string,
   supabaseKey: string,
   options?: SupabaseClientOptions<SchemaName> & {
-    cookies?: CookieMethodsBrowser
-    cookieOptions?: CookieOptionsWithName
-    cookieEncoding?: 'raw' | 'base64url'
-    isSingleton?: boolean
-  }
-): SupabaseClient<Database, SchemaName>
+    cookies?: CookieMethodsBrowser;
+    cookieOptions?: CookieOptionsWithName;
+    cookieEncoding?: "raw" | "base64url";
+    isSingleton?: boolean;
+  },
+): SupabaseClient<Database, SchemaName>;
 
 /**
  * @deprecated Please specify `getAll` and `setAll` cookie methods instead of
@@ -55,60 +59,61 @@ export function createBrowserClient<
  */
 export function createBrowserClient<
   Database = any,
-  SchemaName extends string & keyof Omit<Database, '__InternalSupabase'> =
-    'public' extends keyof Omit<Database, '__InternalSupabase'>
-      ? 'public'
-      : string & keyof Omit<Database, '__InternalSupabase'>,
+  SchemaName extends string & keyof Omit<Database, "__InternalSupabase"> =
+    "public" extends keyof Omit<Database, "__InternalSupabase">
+      ? "public"
+      : string & keyof Omit<Database, "__InternalSupabase">,
 >(
   supabaseUrl: string,
   supabaseKey: string,
   options?: SupabaseClientOptions<SchemaName> & {
-    cookies: CookieMethodsBrowserDeprecated
-    cookieOptions?: CookieOptionsWithName
-    cookieEncoding?: 'raw' | 'base64url'
-    isSingleton?: boolean
-  }
-): SupabaseClient<Database, SchemaName>
+    cookies: CookieMethodsBrowserDeprecated;
+    cookieOptions?: CookieOptionsWithName;
+    cookieEncoding?: "raw" | "base64url";
+    isSingleton?: boolean;
+  },
+): SupabaseClient<Database, SchemaName>;
 
 export function createBrowserClient<
   Database = any,
-  SchemaName extends string & keyof Omit<Database, '__InternalSupabase'> =
-    'public' extends keyof Omit<Database, '__InternalSupabase'>
-      ? 'public'
-      : string & keyof Omit<Database, '__InternalSupabase'>,
+  SchemaName extends string & keyof Omit<Database, "__InternalSupabase"> =
+    "public" extends keyof Omit<Database, "__InternalSupabase">
+      ? "public"
+      : string & keyof Omit<Database, "__InternalSupabase">,
 >(
   supabaseUrl: string,
   supabaseKey: string,
   options?: SupabaseClientOptions<SchemaName> & {
-    cookies?: CookieMethodsBrowser | CookieMethodsBrowserDeprecated
-    cookieOptions?: CookieOptionsWithName
-    cookieEncoding?: 'raw' | 'base64url'
-    isSingleton?: boolean
-  }
+    cookies?: CookieMethodsBrowser | CookieMethodsBrowserDeprecated;
+    cookieOptions?: CookieOptionsWithName;
+    cookieEncoding?: "raw" | "base64url";
+    isSingleton?: boolean;
+  },
 ): SupabaseClient<Database, SchemaName> {
-  warnIfUsingDeprecatedAuthHelpersPackage()
+  warnIfUsingDeprecatedAuthHelpersPackage();
 
   // singleton client is created only if isSingleton is set to true, or if isSingleton is not defined and we detect a browser
   const shouldUseSingleton =
-    options?.isSingleton === true || ((!options || !('isSingleton' in options)) && isBrowser())
+    options?.isSingleton === true ||
+    ((!options || !("isSingleton" in options)) && isBrowser());
 
   if (shouldUseSingleton && cachedBrowserClient) {
-    return cachedBrowserClient
+    return cachedBrowserClient;
   }
 
   if (!supabaseUrl || !supabaseKey) {
     throw new Error(
-      `@supabase/ssr: Your project's URL and API key are required to create a Supabase client!\n\nCheck your Supabase project's API settings to find these values\n\nhttps://supabase.com/dashboard/project/_/settings/api`
-    )
+      `@supabase/ssr: Your project's URL and API key are required to create a Supabase client!\n\nCheck your Supabase project's API settings to find these values\n\nhttps://supabase.com/dashboard/project/_/settings/api`,
+    );
   }
 
   const { storage } = createStorageFromOptions(
     {
       ...options,
-      cookieEncoding: options?.cookieEncoding ?? 'base64url',
+      cookieEncoding: options?.cookieEncoding ?? "base64url",
     },
-    false
-  )
+    false,
+  );
 
   const client = createClient<Database, SchemaName>(supabaseUrl, supabaseKey, {
     // TODO: resolve type error
@@ -117,30 +122,32 @@ export function createBrowserClient<
       ...options?.global,
       headers: {
         ...options?.global?.headers,
-        'X-Client-Info': `supabase-ssr/${VERSION} createBrowserClient`,
+        "X-Client-Info": `supabase-ssr/${VERSION} createBrowserClient`,
       },
     },
     auth: {
       ...options?.auth,
-      ...(options?.cookieOptions?.name ? { storageKey: options.cookieOptions.name } : null),
-      flowType: 'pkce',
+      ...(options?.cookieOptions?.name
+        ? { storageKey: options.cookieOptions.name }
+        : null),
+      flowType: "pkce",
       autoRefreshToken: options?.auth?.autoRefreshToken ?? isBrowser(),
       detectSessionInUrl: options?.auth?.detectSessionInUrl ?? isBrowser(),
       persistSession: options?.auth?.persistSession ?? true,
       storage,
       ...(options?.cookies &&
-      'encode' in options.cookies &&
-      options.cookies.encode === 'tokens-only'
+      "encode" in options.cookies &&
+      options.cookies.encode === "tokens-only"
         ? {
             userStorage: options?.auth?.userStorage ?? window.localStorage,
           }
         : null),
     },
-  })
+  });
 
   if (shouldUseSingleton) {
-    cachedBrowserClient = client
+    cachedBrowserClient = client;
   }
 
-  return client
+  return client;
 }

--- a/src/createServerClient.ts
+++ b/src/createServerClient.ts
@@ -3,17 +3,17 @@ import {
   createClient,
   SupabaseClient,
   SupabaseClientOptions,
-} from "@supabase/supabase-js";
+} from '@supabase/supabase-js'
 
-import { VERSION } from "./version";
-import { createStorageFromOptions, applyServerStorage } from "./cookies";
+import { applyServerStorage, createStorageFromOptions } from './cookies'
 import type {
-  CookieOptionsWithName,
   CookieMethodsServer,
   CookieMethodsServerDeprecated,
-} from "./types";
-import { memoryLocalStorageAdapter } from "./utils/helpers";
-import { warnIfUsingDeprecatedAuthHelpersPackage } from "./warnDeprecatedPackage";
+  CookieOptionsWithName,
+} from './types'
+import { memoryLocalStorageAdapter } from './utils/helpers'
+import { VERSION } from './version'
+import { warnIfUsingDeprecatedAuthHelpersPackage } from './warnDeprecatedPackage'
 
 /**
  * @deprecated Please specify `getAll` and `setAll` cookie methods instead of
@@ -22,19 +22,19 @@ import { warnIfUsingDeprecatedAuthHelpersPackage } from "./warnDeprecatedPackage
  */
 export function createServerClient<
   Database = any,
-  SchemaName extends string & keyof Omit<Database, "__InternalSupabase"> =
-    "public" extends keyof Omit<Database, "__InternalSupabase">
-      ? "public"
-      : string & keyof Omit<Database, "__InternalSupabase">,
+  SchemaName extends string & keyof Omit<Database, '__InternalSupabase'> =
+    'public' extends keyof Omit<Database, '__InternalSupabase'>
+      ? 'public'
+      : string & keyof Omit<Database, '__InternalSupabase'>,
 >(
   supabaseUrl: string,
   supabaseKey: string,
   options: SupabaseClientOptions<SchemaName> & {
-    cookieOptions?: CookieOptionsWithName;
-    cookies: CookieMethodsServerDeprecated;
-    cookieEncoding?: "raw" | "base64url";
-  },
-): SupabaseClient<Database, SchemaName>;
+    cookieOptions?: CookieOptionsWithName
+    cookies: CookieMethodsServerDeprecated
+    cookieEncoding?: 'raw' | 'base64url'
+  }
+): SupabaseClient<Database, SchemaName>
 
 /**
  * Creates a Supabase Client for use on the server-side of a server-side
@@ -87,54 +87,55 @@ export function createServerClient<
  * @param supabaseUrl The URL of the Supabase project.
  * @param supabaseKey The `anon` API key of the Supabase project.
  * @param options Various configuration options.
+ *
+ * @category Clients
  */
 export function createServerClient<
   Database = any,
-  SchemaName extends string & keyof Omit<Database, "__InternalSupabase"> =
-    "public" extends keyof Omit<Database, "__InternalSupabase">
-      ? "public"
-      : string & keyof Omit<Database, "__InternalSupabase">,
+  SchemaName extends string & keyof Omit<Database, '__InternalSupabase'> =
+    'public' extends keyof Omit<Database, '__InternalSupabase'>
+      ? 'public'
+      : string & keyof Omit<Database, '__InternalSupabase'>,
 >(
   supabaseUrl: string,
   supabaseKey: string,
   options: SupabaseClientOptions<SchemaName> & {
-    cookieOptions?: CookieOptionsWithName;
-    cookies: CookieMethodsServer;
-    cookieEncoding?: "raw" | "base64url";
-  },
-): SupabaseClient<Database, SchemaName>;
+    cookieOptions?: CookieOptionsWithName
+    cookies: CookieMethodsServer
+    cookieEncoding?: 'raw' | 'base64url'
+  }
+): SupabaseClient<Database, SchemaName>
 
 export function createServerClient<
   Database = any,
-  SchemaName extends string & keyof Omit<Database, "__InternalSupabase"> =
-    "public" extends keyof Omit<Database, "__InternalSupabase">
-      ? "public"
-      : string & keyof Omit<Database, "__InternalSupabase">,
+  SchemaName extends string & keyof Omit<Database, '__InternalSupabase'> =
+    'public' extends keyof Omit<Database, '__InternalSupabase'>
+      ? 'public'
+      : string & keyof Omit<Database, '__InternalSupabase'>,
 >(
   supabaseUrl: string,
   supabaseKey: string,
   options: SupabaseClientOptions<SchemaName> & {
-    cookieOptions?: CookieOptionsWithName;
-    cookies: CookieMethodsServer | CookieMethodsServerDeprecated;
-    cookieEncoding?: "raw" | "base64url";
-  },
+    cookieOptions?: CookieOptionsWithName
+    cookies: CookieMethodsServer | CookieMethodsServerDeprecated
+    cookieEncoding?: 'raw' | 'base64url'
+  }
 ): SupabaseClient<Database, SchemaName> {
-  warnIfUsingDeprecatedAuthHelpersPackage();
+  warnIfUsingDeprecatedAuthHelpersPackage()
 
   if (!supabaseUrl || !supabaseKey) {
     throw new Error(
-      `Your project's URL and Key are required to create a Supabase client!\n\nCheck your Supabase project's API settings to find these values\n\nhttps://supabase.com/dashboard/project/_/settings/api`,
-    );
+      `Your project's URL and Key are required to create a Supabase client!\n\nCheck your Supabase project's API settings to find these values\n\nhttps://supabase.com/dashboard/project/_/settings/api`
+    )
   }
 
-  const { storage, getAll, setAll, setItems, removedItems } =
-    createStorageFromOptions(
-      {
-        ...options,
-        cookieEncoding: options?.cookieEncoding ?? "base64url",
-      },
-      true,
-    );
+  const { storage, getAll, setAll, setItems, removedItems } = createStorageFromOptions(
+    {
+      ...options,
+      cookieEncoding: options?.cookieEncoding ?? 'base64url',
+    },
+    true
+  )
 
   const client = createClient<Database, SchemaName>(supabaseUrl, supabaseKey, {
     // TODO: resolve type error
@@ -143,30 +144,27 @@ export function createServerClient<
       ...options?.global,
       headers: {
         ...options?.global?.headers,
-        "X-Client-Info": `supabase-ssr/${VERSION} createServerClient`,
+        'X-Client-Info': `supabase-ssr/${VERSION} createServerClient`,
       },
     },
     auth: {
-      ...(options?.cookieOptions?.name
-        ? { storageKey: options.cookieOptions.name }
-        : null),
+      ...(options?.cookieOptions?.name ? { storageKey: options.cookieOptions.name } : null),
       ...options?.auth,
-      flowType: "pkce",
+      flowType: 'pkce',
       autoRefreshToken: false,
       detectSessionInUrl: false,
       persistSession: true,
       skipAutoInitialize: true,
       storage,
       ...(options?.cookies &&
-      "encode" in options.cookies &&
-      options.cookies.encode === "tokens-only"
+      'encode' in options.cookies &&
+      options.cookies.encode === 'tokens-only'
         ? {
-            userStorage:
-              options?.auth?.userStorage ?? memoryLocalStorageAdapter(),
+            userStorage: options?.auth?.userStorage ?? memoryLocalStorageAdapter(),
           }
         : null),
     },
-  });
+  })
 
   client.auth.onAuthStateChange(async (event: AuthChangeEvent) => {
     // The SIGNED_IN event is fired very often, but we don't need to
@@ -174,26 +172,26 @@ export function createServerClient<
     // that need to be set -- which is if setItems / removeItems have
     // data.
     const hasStorageChanges =
-      Object.keys(setItems).length > 0 || Object.keys(removedItems).length > 0;
+      Object.keys(setItems).length > 0 || Object.keys(removedItems).length > 0
 
     if (
       hasStorageChanges &&
-      (event === "SIGNED_IN" ||
-        event === "TOKEN_REFRESHED" ||
-        event === "USER_UPDATED" ||
-        event === "PASSWORD_RECOVERY" ||
-        event === "SIGNED_OUT" ||
-        event === "MFA_CHALLENGE_VERIFIED")
+      (event === 'SIGNED_IN' ||
+        event === 'TOKEN_REFRESHED' ||
+        event === 'USER_UPDATED' ||
+        event === 'PASSWORD_RECOVERY' ||
+        event === 'SIGNED_OUT' ||
+        event === 'MFA_CHALLENGE_VERIFIED')
     ) {
       await applyServerStorage(
         { getAll, setAll, setItems, removedItems },
         {
           cookieOptions: options?.cookieOptions ?? null,
-          cookieEncoding: options?.cookieEncoding ?? "base64url",
-        },
-      );
+          cookieEncoding: options?.cookieEncoding ?? 'base64url',
+        }
+      )
     }
-  });
+  })
 
-  return client;
+  return client
 }

--- a/src/createServerClient.ts
+++ b/src/createServerClient.ts
@@ -3,17 +3,17 @@ import {
   createClient,
   SupabaseClient,
   SupabaseClientOptions,
-} from '@supabase/supabase-js'
+} from "@supabase/supabase-js";
 
-import { applyServerStorage, createStorageFromOptions } from './cookies'
+import { applyServerStorage, createStorageFromOptions } from "./cookies";
 import type {
   CookieMethodsServer,
   CookieMethodsServerDeprecated,
   CookieOptionsWithName,
-} from './types'
-import { memoryLocalStorageAdapter } from './utils/helpers'
-import { VERSION } from './version'
-import { warnIfUsingDeprecatedAuthHelpersPackage } from './warnDeprecatedPackage'
+} from "./types";
+import { memoryLocalStorageAdapter } from "./utils/helpers";
+import { VERSION } from "./version";
+import { warnIfUsingDeprecatedAuthHelpersPackage } from "./warnDeprecatedPackage";
 
 /**
  * @deprecated Please specify `getAll` and `setAll` cookie methods instead of
@@ -22,19 +22,19 @@ import { warnIfUsingDeprecatedAuthHelpersPackage } from './warnDeprecatedPackage
  */
 export function createServerClient<
   Database = any,
-  SchemaName extends string & keyof Omit<Database, '__InternalSupabase'> =
-    'public' extends keyof Omit<Database, '__InternalSupabase'>
-      ? 'public'
-      : string & keyof Omit<Database, '__InternalSupabase'>,
+  SchemaName extends string & keyof Omit<Database, "__InternalSupabase"> =
+    "public" extends keyof Omit<Database, "__InternalSupabase">
+      ? "public"
+      : string & keyof Omit<Database, "__InternalSupabase">,
 >(
   supabaseUrl: string,
   supabaseKey: string,
   options: SupabaseClientOptions<SchemaName> & {
-    cookieOptions?: CookieOptionsWithName
-    cookies: CookieMethodsServerDeprecated
-    cookieEncoding?: 'raw' | 'base64url'
-  }
-): SupabaseClient<Database, SchemaName>
+    cookieOptions?: CookieOptionsWithName;
+    cookies: CookieMethodsServerDeprecated;
+    cookieEncoding?: "raw" | "base64url";
+  },
+): SupabaseClient<Database, SchemaName>;
 
 /**
  * Creates a Supabase Client for use on the server-side of a server-side
@@ -92,50 +92,51 @@ export function createServerClient<
  */
 export function createServerClient<
   Database = any,
-  SchemaName extends string & keyof Omit<Database, '__InternalSupabase'> =
-    'public' extends keyof Omit<Database, '__InternalSupabase'>
-      ? 'public'
-      : string & keyof Omit<Database, '__InternalSupabase'>,
+  SchemaName extends string & keyof Omit<Database, "__InternalSupabase"> =
+    "public" extends keyof Omit<Database, "__InternalSupabase">
+      ? "public"
+      : string & keyof Omit<Database, "__InternalSupabase">,
 >(
   supabaseUrl: string,
   supabaseKey: string,
   options: SupabaseClientOptions<SchemaName> & {
-    cookieOptions?: CookieOptionsWithName
-    cookies: CookieMethodsServer
-    cookieEncoding?: 'raw' | 'base64url'
-  }
-): SupabaseClient<Database, SchemaName>
+    cookieOptions?: CookieOptionsWithName;
+    cookies: CookieMethodsServer;
+    cookieEncoding?: "raw" | "base64url";
+  },
+): SupabaseClient<Database, SchemaName>;
 
 export function createServerClient<
   Database = any,
-  SchemaName extends string & keyof Omit<Database, '__InternalSupabase'> =
-    'public' extends keyof Omit<Database, '__InternalSupabase'>
-      ? 'public'
-      : string & keyof Omit<Database, '__InternalSupabase'>,
+  SchemaName extends string & keyof Omit<Database, "__InternalSupabase"> =
+    "public" extends keyof Omit<Database, "__InternalSupabase">
+      ? "public"
+      : string & keyof Omit<Database, "__InternalSupabase">,
 >(
   supabaseUrl: string,
   supabaseKey: string,
   options: SupabaseClientOptions<SchemaName> & {
-    cookieOptions?: CookieOptionsWithName
-    cookies: CookieMethodsServer | CookieMethodsServerDeprecated
-    cookieEncoding?: 'raw' | 'base64url'
-  }
+    cookieOptions?: CookieOptionsWithName;
+    cookies: CookieMethodsServer | CookieMethodsServerDeprecated;
+    cookieEncoding?: "raw" | "base64url";
+  },
 ): SupabaseClient<Database, SchemaName> {
-  warnIfUsingDeprecatedAuthHelpersPackage()
+  warnIfUsingDeprecatedAuthHelpersPackage();
 
   if (!supabaseUrl || !supabaseKey) {
     throw new Error(
-      `Your project's URL and Key are required to create a Supabase client!\n\nCheck your Supabase project's API settings to find these values\n\nhttps://supabase.com/dashboard/project/_/settings/api`
-    )
+      `Your project's URL and Key are required to create a Supabase client!\n\nCheck your Supabase project's API settings to find these values\n\nhttps://supabase.com/dashboard/project/_/settings/api`,
+    );
   }
 
-  const { storage, getAll, setAll, setItems, removedItems } = createStorageFromOptions(
-    {
-      ...options,
-      cookieEncoding: options?.cookieEncoding ?? 'base64url',
-    },
-    true
-  )
+  const { storage, getAll, setAll, setItems, removedItems } =
+    createStorageFromOptions(
+      {
+        ...options,
+        cookieEncoding: options?.cookieEncoding ?? "base64url",
+      },
+      true,
+    );
 
   const client = createClient<Database, SchemaName>(supabaseUrl, supabaseKey, {
     // TODO: resolve type error
@@ -144,27 +145,30 @@ export function createServerClient<
       ...options?.global,
       headers: {
         ...options?.global?.headers,
-        'X-Client-Info': `supabase-ssr/${VERSION} createServerClient`,
+        "X-Client-Info": `supabase-ssr/${VERSION} createServerClient`,
       },
     },
     auth: {
-      ...(options?.cookieOptions?.name ? { storageKey: options.cookieOptions.name } : null),
+      ...(options?.cookieOptions?.name
+        ? { storageKey: options.cookieOptions.name }
+        : null),
       ...options?.auth,
-      flowType: 'pkce',
+      flowType: "pkce",
       autoRefreshToken: false,
       detectSessionInUrl: false,
       persistSession: true,
       skipAutoInitialize: true,
       storage,
       ...(options?.cookies &&
-      'encode' in options.cookies &&
-      options.cookies.encode === 'tokens-only'
+      "encode" in options.cookies &&
+      options.cookies.encode === "tokens-only"
         ? {
-            userStorage: options?.auth?.userStorage ?? memoryLocalStorageAdapter(),
+            userStorage:
+              options?.auth?.userStorage ?? memoryLocalStorageAdapter(),
           }
         : null),
     },
-  })
+  });
 
   client.auth.onAuthStateChange(async (event: AuthChangeEvent) => {
     // The SIGNED_IN event is fired very often, but we don't need to
@@ -172,26 +176,26 @@ export function createServerClient<
     // that need to be set -- which is if setItems / removeItems have
     // data.
     const hasStorageChanges =
-      Object.keys(setItems).length > 0 || Object.keys(removedItems).length > 0
+      Object.keys(setItems).length > 0 || Object.keys(removedItems).length > 0;
 
     if (
       hasStorageChanges &&
-      (event === 'SIGNED_IN' ||
-        event === 'TOKEN_REFRESHED' ||
-        event === 'USER_UPDATED' ||
-        event === 'PASSWORD_RECOVERY' ||
-        event === 'SIGNED_OUT' ||
-        event === 'MFA_CHALLENGE_VERIFIED')
+      (event === "SIGNED_IN" ||
+        event === "TOKEN_REFRESHED" ||
+        event === "USER_UPDATED" ||
+        event === "PASSWORD_RECOVERY" ||
+        event === "SIGNED_OUT" ||
+        event === "MFA_CHALLENGE_VERIFIED")
     ) {
       await applyServerStorage(
         { getAll, setAll, setItems, removedItems },
         {
           cookieOptions: options?.cookieOptions ?? null,
-          cookieEncoding: options?.cookieEncoding ?? 'base64url',
-        }
-      )
+          cookieEncoding: options?.cookieEncoding ?? "base64url",
+        },
+      );
     }
-  })
+  });
 
-  return client
+  return client;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,27 +1,31 @@
-import type { SerializeOptions } from "cookie";
+import type { SerializeOptions } from 'cookie'
 
-export type CookieOptions = Partial<SerializeOptions>;
-export type CookieOptionsWithName = { name?: string } & CookieOptions;
+/** @category Types */
+export type CookieOptions = Partial<SerializeOptions>
+/** @category Types */
+export type CookieOptionsWithName = { name?: string } & CookieOptions
 
+/** @category Types */
 export type GetCookie = (
-  name: string,
-) => Promise<string | null | undefined> | string | null | undefined;
+  name: string
+) => Promise<string | null | undefined> | string | null | undefined
 
+/** @category Types */
 export type SetCookie = (
   name: string,
   value: string,
-  options: CookieOptions,
-) => Promise<void> | void;
-export type RemoveCookie = (
-  name: string,
-  options: CookieOptions,
-) => Promise<void> | void;
+  options: CookieOptions
+) => Promise<void> | void
+/** @category Types */
+export type RemoveCookie = (name: string, options: CookieOptions) => Promise<void> | void
 
+/** @category Types */
 export type GetAllCookies = () =>
   | Promise<{ name: string; value: string }[] | null>
   | { name: string; value: string }[]
-  | null;
+  | null
 
+/** @category Types */
 export type SetAllCookies = (
   cookies: { name: string; value: string; options: CookieOptions }[],
   /**
@@ -48,15 +52,17 @@ export type SetAllCookies = (
    * }
    * ```
    */
-  headers: Record<string, string>,
-) => Promise<void> | void;
+  headers: Record<string, string>
+) => Promise<void> | void
 
+/** @category Types */
 export type CookieMethodsBrowserDeprecated = {
-  get: GetCookie;
-  set: SetCookie;
-  remove: RemoveCookie;
-};
+  get: GetCookie
+  set: SetCookie
+  remove: RemoveCookie
+}
 
+/** @category Types */
 export type CookieMethodsBrowser = {
   /**
    * If set to true, only the user's session (access and refresh tokens) will be encoded in cookies. The user object will be encoded in local storage if the `userStorage` option is not provided when creating the client.
@@ -65,7 +71,7 @@ export type CookieMethodsBrowser = {
    *
    * @experimental
    */
-  encode?: "user-and-tokens" | "tokens-only";
+  encode?: 'user-and-tokens' | 'tokens-only'
 
   /**
    * Required when reading cookies from a custom store. If both `getAll` and
@@ -74,21 +80,23 @@ export type CookieMethodsBrowser = {
    * persisted in cookies regardless of the `encode` option, so cookie access
    * (custom or fallback) is required for auth to work.
    */
-  getAll?: GetAllCookies;
+  getAll?: GetAllCookies
   /**
    * Required alongside `getAll` when using a custom cookie store. If both
    * `getAll` and `setAll` are omitted in a browser runtime, the client falls
    * back to writing via `document.cookie`.
    */
-  setAll?: SetAllCookies;
-};
+  setAll?: SetAllCookies
+}
 
+/** @category Types */
 export type CookieMethodsServerDeprecated = {
-  get: GetCookie;
-  set?: SetCookie;
-  remove?: RemoveCookie;
-};
+  get: GetCookie
+  set?: SetCookie
+  remove?: RemoveCookie
+}
 
+/** @category Types */
 export type CookieMethodsServer = {
   /**
    * If set to `tokens-only`, only the user's access and refresh tokens will be encoded in cookies. The user object will be encoded in memory if the `userStorage` option is not provided when creating the client. Unset value defaults to `user-and-tokens`.
@@ -97,9 +105,9 @@ export type CookieMethodsServer = {
    *
    * @experimental
    */
-  encode?: "user-and-tokens" | "tokens-only";
+  encode?: 'user-and-tokens' | 'tokens-only'
 
-  getAll: GetAllCookies;
+  getAll: GetAllCookies
 
   /**
    * Called by the Supabase Client to write cookies to the response after a
@@ -121,5 +129,5 @@ export type CookieMethodsServer = {
    * See the [official server-side rendering guides](https://supabase.com/docs/guides/auth/server-side)
    * for guidance on choosing between `getSession()`, `getUser()`, and `getClaims()`.
    */
-  setAll?: SetAllCookies;
-};
+  setAll?: SetAllCookies
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,29 +1,32 @@
-import type { SerializeOptions } from 'cookie'
+import type { SerializeOptions } from "cookie";
 
 /** @category Types */
-export type CookieOptions = Partial<SerializeOptions>
+export type CookieOptions = Partial<SerializeOptions>;
 /** @category Types */
-export type CookieOptionsWithName = { name?: string } & CookieOptions
+export type CookieOptionsWithName = { name?: string } & CookieOptions;
 
 /** @category Types */
 export type GetCookie = (
-  name: string
-) => Promise<string | null | undefined> | string | null | undefined
+  name: string,
+) => Promise<string | null | undefined> | string | null | undefined;
 
 /** @category Types */
 export type SetCookie = (
   name: string,
   value: string,
-  options: CookieOptions
-) => Promise<void> | void
+  options: CookieOptions,
+) => Promise<void> | void;
 /** @category Types */
-export type RemoveCookie = (name: string, options: CookieOptions) => Promise<void> | void
+export type RemoveCookie = (
+  name: string,
+  options: CookieOptions,
+) => Promise<void> | void;
 
 /** @category Types */
 export type GetAllCookies = () =>
   | Promise<{ name: string; value: string }[] | null>
   | { name: string; value: string }[]
-  | null
+  | null;
 
 /** @category Types */
 export type SetAllCookies = (
@@ -52,15 +55,15 @@ export type SetAllCookies = (
    * }
    * ```
    */
-  headers: Record<string, string>
-) => Promise<void> | void
+  headers: Record<string, string>,
+) => Promise<void> | void;
 
 /** @category Types */
 export type CookieMethodsBrowserDeprecated = {
-  get: GetCookie
-  set: SetCookie
-  remove: RemoveCookie
-}
+  get: GetCookie;
+  set: SetCookie;
+  remove: RemoveCookie;
+};
 
 /** @category Types */
 export type CookieMethodsBrowser = {
@@ -71,7 +74,7 @@ export type CookieMethodsBrowser = {
    *
    * @experimental
    */
-  encode?: 'user-and-tokens' | 'tokens-only'
+  encode?: "user-and-tokens" | "tokens-only";
 
   /**
    * Required when reading cookies from a custom store. If both `getAll` and
@@ -80,21 +83,21 @@ export type CookieMethodsBrowser = {
    * persisted in cookies regardless of the `encode` option, so cookie access
    * (custom or fallback) is required for auth to work.
    */
-  getAll?: GetAllCookies
+  getAll?: GetAllCookies;
   /**
    * Required alongside `getAll` when using a custom cookie store. If both
    * `getAll` and `setAll` are omitted in a browser runtime, the client falls
    * back to writing via `document.cookie`.
    */
-  setAll?: SetAllCookies
-}
+  setAll?: SetAllCookies;
+};
 
 /** @category Types */
 export type CookieMethodsServerDeprecated = {
-  get: GetCookie
-  set?: SetCookie
-  remove?: RemoveCookie
-}
+  get: GetCookie;
+  set?: SetCookie;
+  remove?: RemoveCookie;
+};
 
 /** @category Types */
 export type CookieMethodsServer = {
@@ -105,9 +108,9 @@ export type CookieMethodsServer = {
    *
    * @experimental
    */
-  encode?: 'user-and-tokens' | 'tokens-only'
+  encode?: "user-and-tokens" | "tokens-only";
 
-  getAll: GetAllCookies
+  getAll: GetAllCookies;
 
   /**
    * Called by the Supabase Client to write cookies to the response after a
@@ -129,5 +132,5 @@ export type CookieMethodsServer = {
    * See the [official server-side rendering guides](https://supabase.com/docs/guides/auth/server-side)
    * for guidance on choosing between `getSession()`, `getUser()`, and `getClaims()`.
    */
-  setAll?: SetAllCookies
-}
+  setAll?: SetAllCookies;
+};

--- a/src/warnDeprecatedPackage.ts
+++ b/src/warnDeprecatedPackage.ts
@@ -1,11 +1,11 @@
-let warned = false
+let warned = false;
 
 const DEPRECATED_PACKAGES = [
-  '@supabase/auth-helpers-nextjs',
-  '@supabase/auth-helpers-react',
-  '@supabase/auth-helpers-remix',
-  '@supabase/auth-helpers-sveltekit',
-]
+  "@supabase/auth-helpers-nextjs",
+  "@supabase/auth-helpers-react",
+  "@supabase/auth-helpers-remix",
+  "@supabase/auth-helpers-sveltekit",
+];
 
 /**
  * Emits a one-time console warning when the running app still declares one of
@@ -16,19 +16,19 @@ const DEPRECATED_PACKAGES = [
  */
 export function warnIfUsingDeprecatedAuthHelpersPackage(): void {
   if (warned) {
-    return
+    return;
   }
 
-  if (typeof process === 'undefined' || !process.env?.npm_package_name) {
-    return
+  if (typeof process === "undefined" || !process.env?.npm_package_name) {
+    return;
   }
 
-  const packageName = process.env.npm_package_name
+  const packageName = process.env.npm_package_name;
   if (!DEPRECATED_PACKAGES.includes(packageName)) {
-    return
+    return;
   }
 
-  warned = true
+  warned = true;
   console.warn(`
 ╔════════════════════════════════════════════════════════════════════════════╗
 ║ ⚠️  IMPORTANT: Package Consolidation Notice                                ║
@@ -47,5 +47,5 @@ export function warnIfUsingDeprecatedAuthHelpersPackage(): void {
 ║ For more information, visit:                                              ║
 ║ https://supabase.com/docs/guides/auth/server-side                         ║
 ╚════════════════════════════════════════════════════════════════════════════╝
-    `)
+    `);
 }

--- a/src/warnDeprecatedPackage.ts
+++ b/src/warnDeprecatedPackage.ts
@@ -1,27 +1,34 @@
-let warned = false;
+let warned = false
 
 const DEPRECATED_PACKAGES = [
-  "@supabase/auth-helpers-nextjs",
-  "@supabase/auth-helpers-react",
-  "@supabase/auth-helpers-remix",
-  "@supabase/auth-helpers-sveltekit",
-];
+  '@supabase/auth-helpers-nextjs',
+  '@supabase/auth-helpers-react',
+  '@supabase/auth-helpers-remix',
+  '@supabase/auth-helpers-sveltekit',
+]
 
+/**
+ * Emits a one-time console warning when the running app still declares one of
+ * the deprecated `@supabase/auth-helpers-*` packages, nudging consumers to
+ * migrate to `@supabase/ssr`. No-op outside Node-like runtimes.
+ *
+ * @category Deprecated
+ */
 export function warnIfUsingDeprecatedAuthHelpersPackage(): void {
   if (warned) {
-    return;
+    return
   }
 
-  if (typeof process === "undefined" || !process.env?.npm_package_name) {
-    return;
+  if (typeof process === 'undefined' || !process.env?.npm_package_name) {
+    return
   }
 
-  const packageName = process.env.npm_package_name;
+  const packageName = process.env.npm_package_name
   if (!DEPRECATED_PACKAGES.includes(packageName)) {
-    return;
+    return
   }
 
-  warned = true;
+  warned = true
   console.warn(`
 ╔════════════════════════════════════════════════════════════════════════════╗
 ║ ⚠️  IMPORTANT: Package Consolidation Notice                                ║
@@ -40,5 +47,5 @@ export function warnIfUsingDeprecatedAuthHelpersPackage(): void {
 ║ For more information, visit:                                              ║
 ║ https://supabase.com/docs/guides/auth/server-side                         ║
 ╚════════════════════════════════════════════════════════════════════════════╝
-    `);
+    `)
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -12,7 +12,14 @@
   "navigationLinks": {
     "GitHub": "https://github.com/supabase/ssr"
   },
-  "highlightLanguages": ["typescript", "javascript", "tsx", "bash", "sh", "json"],
+  "highlightLanguages": [
+    "typescript",
+    "javascript",
+    "tsx",
+    "bash",
+    "sh",
+    "json"
+  ],
   "sort": ["source-order"],
   "kindSortOrder": ["Function", "Class", "Interface", "TypeAlias", "Enum"],
   "categorizeByGroup": true

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": ["src/index.ts"],
+  "out": "api-docs",
+  "json": "api-docs/spec.json",
+  "name": "@supabase/ssr",
+  "readme": "README.md",
+  "includeVersion": true,
+  "excludePrivate": true,
+  "excludeProtected": true,
+  "excludeExternals": true,
+  "navigationLinks": {
+    "GitHub": "https://github.com/supabase/ssr"
+  },
+  "highlightLanguages": ["typescript", "javascript", "tsx", "bash", "sh", "json"],
+  "sort": ["source-order"],
+  "kindSortOrder": ["Function", "Class", "Interface", "TypeAlias", "Enum"],
+  "categorizeByGroup": true
+}


### PR DESCRIPTION
Sets up TypeDoc for generating API reference documentation. Adds a `typedoc.json` config targeting `src/index.ts`, a `docs` script that builds HTML output plus a `spec.json`, and a GitHub Actions workflow that builds and deploys the docs to GitHub Pages on pushes to `main`.

Also adds `@category` JSDoc tags across public exports (clients, cookie helpers, types) so TypeDoc groups them sensibly, and reorders a few imports for consistency.