### PR TITLE
fix: flush PKCE verifier slot removals on the server

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -344,11 +344,16 @@ and the per-flow keys auth-js uses to keep several PKCE flows in flight at once
 (`<storageKey>-flow-<flowId>-code-verifier`, plus the
 `<storageKey>-flows-code-verifier` index of pending flow ids).
 
-Removals are normally left buffered, because the removal of a verifier during
-`exchangeCodeForSession` is immediately followed by an event that applies the
-storage anyway. Per-flow verifier slots are the one exception: auth-js bounds
-the number of concurrent flows with a ring that evicts the oldest slot when a
-new flow _starts_, and a flow start fires no event. Since the write that drops
-the evicted id from the index is applied, a buffered eviction would leave the
-slot's cookie behind with nothing referencing it, so slot removals are applied
-immediately too.
+Removal of the fixed `<storageKey>-code-verifier` key is left buffered. On a
+successful `exchangeCodeForSession` an event follows immediately and applies the
+storage; on a failure no event fires, but that key holds a single value which
+the next flow's write overwrites, so a removal that never reaches the browser is
+not observable.
+
+The per-flow keys are removed immediately instead, because both of the paths
+that remove them can emit no event at all. auth-js bounds the number of
+concurrent flows with a ring that evicts the oldest slot when a new flow
+_starts_, and a flow that fails removes its own slot from a catch block,
+dropping the index entry too when it was the last one. Leaving those buffered
+would strand a verifier cookie in the browser with nothing referencing it, or an
+index naming a slot that is already gone.

--- a/docs/design.md
+++ b/docs/design.md
@@ -327,6 +327,28 @@ There are two key points to identify from this about the behavior of
 2. **Cookies are set when the storage values change. Set-Cookie headers should
    not be sent out if there is no change.** Therefore cookies are set only on
    these `onAuthStateChange` events:
+   - `SIGNED_IN` -- when a session was established, such as by exchanging a PKCE code
    - `TOKEN_REFRESHED` -- when the access token was expired
    - `USER_UPDATED` -- usually only in pattern 3 -- routes or APIs that call the `updateUser()` API
+   - `PASSWORD_RECOVERY` -- when a recovery link established a session
    - `SIGNED_OUT` when the session expired or was terminated, such as the user signing out from another device
+   - `MFA_CHALLENGE_VERIFIED` -- when a multi-factor challenge was completed
+
+#### Exception: PKCE code verifiers
+
+There is no `onAuthStateChange` event that announces a PKCE code verifier being
+written, so waiting for one would drop the verifier and break the flow. The
+server storage therefore applies the storage immediately for any key ending in
+`-code-verifier`, which covers both the fixed `<storageKey>-code-verifier` key
+and the per-flow keys auth-js uses to keep several PKCE flows in flight at once
+(`<storageKey>-flow-<flowId>-code-verifier`, plus the
+`<storageKey>-flows-code-verifier` index of pending flow ids).
+
+Removals are normally left buffered, because the removal of a verifier during
+`exchangeCodeForSession` is immediately followed by an event that applies the
+storage anyway. Per-flow verifier slots are the one exception: auth-js bounds
+the number of concurrent flows with a ring that evicts the oldest slot when a
+new flow _starts_, and a flow start fires no event. Since the write that drops
+the evicted id from the index is applied, a buffered eviction would leave the
+slot's cookie behind with nothing referencing it, so slot removals are applied
+immediately too.

--- a/src/cookies.spec.ts
+++ b/src/cookies.spec.ts
@@ -11,6 +11,7 @@ import { CookieOptions } from "./types";
 import {
   createStorageFromOptions,
   applyServerStorage,
+  isPkceFlowIndexKey,
   isPkceVerifierSlotKey,
 } from "./cookies";
 
@@ -367,6 +368,11 @@ describe("createStorageFromOptions for createServerClient", () => {
 
         expect(slots.filter(isPkceVerifierSlotKey)).toEqual(slots);
         expect(notSlots.filter(isPkceVerifierSlotKey)).toEqual([]);
+
+        // the index is matched separately, and only the index
+        expect(isPkceFlowIndexKey(INDEX_KEY)).toBe(true);
+        expect(slots.filter(isPkceFlowIndexKey)).toEqual([]);
+        expect(isPkceFlowIndexKey(LEGACY_KEY)).toBe(false);
       });
 
       it("should call setAll on setItem for the fixed code verifier key", async () => {
@@ -425,7 +431,11 @@ describe("createStorageFromOptions for createServerClient", () => {
         expect(removedItems).toEqual({ [LEGACY_KEY]: true });
       });
 
-      it("should not call setAll on removeItem for the flow index key", async () => {
+      it("should call setAll on removeItem for the flow index key", async () => {
+        // the index is dropped when the last pending flow goes away, which
+        // happens from a catch block on a failed flow with no auth event to
+        // apply the storage. Leaving it buffered would keep an index in the
+        // browser naming a slot that was already cleared.
         const setAllCalls: SetAllCall[] = [];
         const { storage, removedItems } = createServerStorageWithSetAll(
           recordInto(setAllCalls),
@@ -434,7 +444,10 @@ describe("createStorageFromOptions for createServerClient", () => {
 
         await storage.removeItem(INDEX_KEY);
 
-        expect(setAllCalls).toEqual([]);
+        expect(setAllCalls).toHaveLength(1);
+        expect(setAllCalls[0].cookies).toEqual([
+          { name: INDEX_KEY, value: "", options: removedCookieOptions },
+        ]);
         expect(removedItems).toEqual({ [INDEX_KEY]: true });
       });
 

--- a/src/cookies.spec.ts
+++ b/src/cookies.spec.ts
@@ -8,7 +8,11 @@ import {
 } from "./utils";
 import { CookieOptions } from "./types";
 
-import { createStorageFromOptions, applyServerStorage } from "./cookies";
+import {
+  createStorageFromOptions,
+  applyServerStorage,
+  isPkceVerifierSlotKey,
+} from "./cookies";
 
 describe("createStorageFromOptions in browser without cookie methods", () => {
   beforeEach(() => {
@@ -325,6 +329,160 @@ describe("createStorageFromOptions for createServerClient", () => {
       expect(setAllCalled).toBeFalsy();
       expect(setItems).toEqual({});
       expect(removedItems).toEqual({ "storage-key": true });
+    });
+
+    describe("PKCE code verifier keys", () => {
+      // auth-js has no `onAuthStateChange` event to announce a verifier write,
+      // so the storage is applied immediately for the verifier key family.
+      const STORAGE_KEY = "sb-project-ref-auth-token";
+      const LEGACY_KEY = `${STORAGE_KEY}-code-verifier`;
+      const INDEX_KEY = `${STORAGE_KEY}-flows-code-verifier`;
+      const slotKey = (flowId: string) =>
+        `${STORAGE_KEY}-flow-${flowId}-code-verifier`;
+      // shaped like a real flow id: 32 hex characters
+      const FLOW_ID = "0123456789abcdef0123456789abcdef";
+
+      const removedCookieOptions = { ...DEFAULT_COOKIE_OPTIONS, maxAge: 0 };
+
+      const recordInto =
+        (calls: SetAllCall[]) =>
+        async (
+          cookies: SetAllCall["cookies"],
+          headers: SetAllCall["headers"],
+        ) => {
+          calls.push({ cookies, headers });
+        };
+
+      it("recognizes only per-flow slot keys as verifier slots", () => {
+        const slots = [slotKey(FLOW_ID), slotKey("flow-id-with-dashes")];
+        const notSlots = [
+          // the fixed key and the flow index are not slots
+          LEGACY_KEY,
+          INDEX_KEY,
+          STORAGE_KEY,
+          // too short to be a flow id, so a storage key that happens to
+          // contain `-flow-` does not look like a slot
+          "my-flow-abc-code-verifier",
+        ];
+
+        expect(slots.filter(isPkceVerifierSlotKey)).toEqual(slots);
+        expect(notSlots.filter(isPkceVerifierSlotKey)).toEqual([]);
+      });
+
+      it("should call setAll on setItem for the fixed code verifier key", async () => {
+        const setAllCalls: SetAllCall[] = [];
+        const { storage, setItems } = createServerStorageWithSetAll(
+          recordInto(setAllCalls),
+        );
+
+        await storage.setItem(LEGACY_KEY, "verifier-value");
+
+        expect(setAllCalls).toHaveLength(1);
+        expect(setAllCalls[0].cookies).toEqual([
+          {
+            name: LEGACY_KEY,
+            value: "verifier-value",
+            options: { ...DEFAULT_COOKIE_OPTIONS },
+          },
+        ]);
+        // the buffer is still updated so a later applyServerStorage agrees
+        expect(setItems).toEqual({ [LEGACY_KEY]: "verifier-value" });
+      });
+
+      it("should call setAll on removeItem for a verifier slot key", async () => {
+        const setAllCalls: SetAllCall[] = [];
+        const { storage, setItems, removedItems } =
+          createServerStorageWithSetAll(recordInto(setAllCalls), async () => [
+            { name: slotKey(FLOW_ID), value: "verifier-value" },
+          ]);
+
+        await storage.removeItem(slotKey(FLOW_ID));
+
+        expect(setAllCalls).toHaveLength(1);
+        expect(setAllCalls[0].cookies).toEqual([
+          {
+            name: slotKey(FLOW_ID),
+            value: "",
+            options: removedCookieOptions,
+          },
+        ]);
+        expect(setItems).toEqual({});
+        expect(removedItems).toEqual({ [slotKey(FLOW_ID)]: true });
+      });
+
+      it("should not call setAll on removeItem for the fixed code verifier key", async () => {
+        const setAllCalls: SetAllCall[] = [];
+        const { storage, removedItems } = createServerStorageWithSetAll(
+          recordInto(setAllCalls),
+          async () => [{ name: LEGACY_KEY, value: "verifier-value" }],
+        );
+
+        await storage.removeItem(LEGACY_KEY);
+
+        // stays buffered: the exchange that removes it is followed by an auth
+        // event which applies the storage
+        expect(setAllCalls).toEqual([]);
+        expect(removedItems).toEqual({ [LEGACY_KEY]: true });
+      });
+
+      it("should not call setAll on removeItem for the flow index key", async () => {
+        const setAllCalls: SetAllCall[] = [];
+        const { storage, removedItems } = createServerStorageWithSetAll(
+          recordInto(setAllCalls),
+          async () => [{ name: INDEX_KEY, value: "[]" }],
+        );
+
+        await storage.removeItem(INDEX_KEY);
+
+        expect(setAllCalls).toEqual([]);
+        expect(removedItems).toEqual({ [INDEX_KEY]: true });
+      });
+
+      it("clears the evicted slot cookie when a flow start overflows the ring", async () => {
+        // auth-js bounds concurrent flows at 5. Starting a 6th evicts the
+        // oldest slot and rewrites the index without it. The index write is
+        // applied, so if the eviction were only buffered -- no auth event
+        // fires on a flow *start* -- the evicted cookie would survive with
+        // nothing left referencing it.
+        const flowIds = [1, 2, 3, 4, 5, 6].map((n) => `${n}`.repeat(32));
+        const cookieStore: Record<string, string> = {
+          [LEGACY_KEY]: "verifier-5",
+          [INDEX_KEY]: JSON.stringify(flowIds.slice(0, 5)),
+        };
+        flowIds.slice(0, 5).forEach((flowId, i) => {
+          cookieStore[slotKey(flowId)] = `verifier-${i + 1}`;
+        });
+
+        const { storage } = createServerStorageWithSetAll(
+          async (setCookies) => {
+            setCookies.forEach(({ name, value }) => {
+              if (value) {
+                cookieStore[name] = value;
+              } else {
+                delete cookieStore[name];
+              }
+            });
+          },
+          async () =>
+            Object.entries(cookieStore).map(([name, value]) => ({
+              name,
+              value,
+            })),
+        );
+
+        // the writes auth-js performs when starting the 6th flow
+        await storage.setItem(slotKey(flowIds[5]), "verifier-6");
+        await storage.removeItem(slotKey(flowIds[0]));
+        await storage.setItem(INDEX_KEY, JSON.stringify(flowIds.slice(1)));
+        await storage.setItem(LEGACY_KEY, "verifier-6");
+
+        expect(Object.keys(cookieStore).filter(isPkceVerifierSlotKey)).toEqual(
+          flowIds.slice(1).map(slotKey),
+        );
+        // the evicted slot is gone rather than orphaned
+        expect(cookieStore[slotKey(flowIds[0])]).toBeUndefined();
+        expect(cookieStore[slotKey(flowIds[5])]).toBe("verifier-6");
+      });
     });
 
     it("should not call getAll if item has already been set", async () => {

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -41,6 +41,18 @@ export function isPkceVerifierSlotKey(key: string): boolean {
   return PKCE_VERIFIER_SLOT_KEY.test(key);
 }
 
+const PKCE_FLOW_INDEX_SUFFIX = "-flows-code-verifier";
+
+/**
+ * Matches auth-js's index of pending PKCE flow ids,
+ * `<storageKey>-flows-code-verifier`. Storage adapters cannot enumerate keys,
+ * so this entry is what makes the verifier slots discoverable for eviction and
+ * for teardown on sign-out.
+ */
+export function isPkceFlowIndexKey(key: string): boolean {
+  return key.endsWith(PKCE_FLOW_INDEX_SUFFIX);
+}
+
 /**
  * Decodes a chunked cookie value that may carry the `base64-` prefix written
  * by this module. When the prefix is present, the underlying payload is always
@@ -478,27 +490,31 @@ export function createStorageFromOptions(
         delete removedItems[key];
       },
       removeItem: async (key: string) => {
-        // Intentionally not applying the storage when the key is the PKCE code
-        // verifier, as usually right after it's removed other items are set,
-        // so application of the storage will be handled by the
+        // Intentionally not applying the storage when the key is the fixed
+        // PKCE code verifier, as usually right after it's removed other items
+        // are set, so application of the storage will be handled by the
         // `onAuthStateChange` callback that follows removal -- usually as part
-        // of the `exchangeCodeForSession` call.
+        // of the `exchangeCodeForSession` call. That key holds a single value
+        // which the next flow's `setItem` overwrites (applied immediately, see
+        // setItem above), so a removal that never reaches the browser is not
+        // observable.
         //
-        // Per-flow verifier slots are the exception. auth-js bounds the number
-        // of concurrent PKCE flows with a ring that evicts the oldest slot
-        // during a flow *start*, where no auth event follows to apply the
-        // storage. The write that drops the evicted id from the flow index
-        // *is* applied (it ends in `-code-verifier`, see setItem above), so
-        // without this the slot's cookie would outlive every reference to it
-        // and never be cleaned up again.
-        if (isPkceVerifierSlotKey(key)) {
+        // The per-flow verifier slots and the index of pending flow ids are
+        // the exception, because they can be removed on paths that emit no
+        // auth event at all: auth-js's ring evicts the oldest slot during a
+        // flow *start*, and a flow that fails removes its own slot (and the
+        // index entry, when it was the last one) from a catch block. Leaving
+        // those buffered would strand a verifier cookie in the browser with
+        // nothing referencing it, or an index that names a slot which is
+        // already gone.
+        if (isPkceVerifierSlotKey(key) || isPkceFlowIndexKey(key)) {
           await applyServerStorage(
             {
               getAll,
               setAll,
               // pretend that nothing was set
               setItems: {},
-              // pretend only that the verifier slot was removed
+              // pretend only that this verifier key was removed
               removedItems: { [key]: true },
             },
             {

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -24,6 +24,24 @@ import type {
 const BASE64_PREFIX = "base64-";
 
 /**
+ * Matches the storage key auth-js uses for a single in-flight PKCE flow's code
+ * verifier: `<storageKey>-flow-<flowId>-code-verifier`.
+ *
+ * The length bound mirrors auth-js's own flow id validation, so a storage key
+ * that happens to contain `-flow-` is not mistaken for a verifier slot.
+ *
+ * Deliberately does not match the two neighbouring keys:
+ * - `<storageKey>-code-verifier`, the fixed key written for every flow.
+ * - `<storageKey>-flows-code-verifier`, the index of pending flow ids. There is
+ *   no `-` after `flow` there, so the pattern cannot match it.
+ */
+const PKCE_VERIFIER_SLOT_KEY = /-flow-[A-Za-z0-9_-]{8,64}-code-verifier$/;
+
+export function isPkceVerifierSlotKey(key: string): boolean {
+  return PKCE_VERIFIER_SLOT_KEY.test(key);
+}
+
+/**
  * Decodes a chunked cookie value that may carry the `base64-` prefix written
  * by this module. When the prefix is present, the underlying payload is always
  * JSON encoded by auth-js (`setItemAsync` runs `JSON.stringify` on every
@@ -465,6 +483,31 @@ export function createStorageFromOptions(
         // so application of the storage will be handled by the
         // `onAuthStateChange` callback that follows removal -- usually as part
         // of the `exchangeCodeForSession` call.
+        //
+        // Per-flow verifier slots are the exception. auth-js bounds the number
+        // of concurrent PKCE flows with a ring that evicts the oldest slot
+        // during a flow *start*, where no auth event follows to apply the
+        // storage. The write that drops the evicted id from the flow index
+        // *is* applied (it ends in `-code-verifier`, see setItem above), so
+        // without this the slot's cookie would outlive every reference to it
+        // and never be cleaned up again.
+        if (isPkceVerifierSlotKey(key)) {
+          await applyServerStorage(
+            {
+              getAll,
+              setAll,
+              // pretend that nothing was set
+              setItems: {},
+              // pretend only that the verifier slot was removed
+              removedItems: { [key]: true },
+            },
+            {
+              cookieOptions: options?.cookieOptions ?? null,
+              cookieEncoding,
+            },
+          );
+        }
+
         delete setItems[key];
         removedItems[key] = true;
       },


### PR DESCRIPTION
auth-js stores each in-flight PKCE code verifier in its own cookie slot (`<storageKey>-flow-<flowId>-code-verifier`), bounded by a ring of five. The server storage applies writes to `-code-verifier` keys immediately but leaves removals buffered until an `onAuthStateChange` event, and a flow start fires no such event: when the ring evicts the oldest slot, that removal is discarded while the index write dropping the evicted id is applied, orphaning a verifier cookie that nothing references and no cleanup path can reach.

This applies the storage on removal for per-flow slot keys only, so the fixed `-code-verifier` key and the `-flows-code-verifier` index keep their existing buffered behavior and no current code path changes. Impact is cookie hygiene rather than credential exposure, since a verifier with no matching auth code grants nothing.

`docs/design.md` is the only place documenting when the server applies storage to cookies, so the new exception is recorded there. That section also never mentioned the existing immediate flush for verifier writes, and its event list had drifted from `createServerClient.ts`, so both are corrected alongside it.