### PR TITLE
fix: avoid duplicate cache headers per server client

### DIFF
--- a/src/cookies.spec.ts
+++ b/src/cookies.spec.ts
@@ -280,6 +280,35 @@ describe("createStorageFromOptions for createServerClient", () => {
         true,
       );
 
+    it("should retry cache headers when setAll rejects", async () => {
+      const cacheHeaders = {
+        "Cache-Control": "no-store",
+        Expires: "0",
+        Pragma: "no-cache",
+      };
+      const cookiesToSet = [{ name: "cookie", value: "value", options: {} }];
+      const receivedHeaders: Record<string, string>[] = [];
+      let setAllCalls = 0;
+
+      const { setAll } = createServerStorageWithSetAll(
+        async (_setCookies, headers) => {
+          setAllCalls += 1;
+          receivedHeaders.push(headers);
+
+          if (setAllCalls === 1) {
+            throw new Error("setAll failed");
+          }
+        },
+      );
+
+      await expect(setAll(cookiesToSet, cacheHeaders)).rejects.toThrow(
+        "setAll failed",
+      );
+      await expect(setAll(cookiesToSet, cacheHeaders)).resolves.toBeUndefined();
+
+      expect(receivedHeaders).toEqual([cacheHeaders, cacheHeaders]);
+    });
+
     it("should not call setAll on setItem", async () => {
       let setAllCalled = false;
 

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -413,6 +413,20 @@ export function createStorageFromOptions(
     };
   }
 
+  const originalSetAll = setAll;
+  let hasSentHeaders = false;
+
+  setAll = async (setCookies, headers) => {
+    const shouldSendHeaders =
+      !hasSentHeaders && Object.keys(headers).length > 0;
+
+    if (shouldSendHeaders) {
+      hasSentHeaders = true;
+    }
+
+    await originalSetAll(setCookies, shouldSendHeaders ? headers : {});
+  };
+
   // This is the server client. It only uses getAll to read the initial
   // state. Any subsequent changes to the items is persisted in the
   // setItems and removedItems objects. createServerClient *must* use

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -420,11 +420,11 @@ export function createStorageFromOptions(
     const shouldSendHeaders =
       !hasSentHeaders && Object.keys(headers).length > 0;
 
+    await originalSetAll(setCookies, shouldSendHeaders ? headers : {});
+
     if (shouldSendHeaders) {
       hasSentHeaders = true;
     }
-
-    await originalSetAll(setCookies, shouldSendHeaders ? headers : {});
   };
 
   // This is the server client. It only uses getAll to read the initial

--- a/src/createServerClient.spec.ts
+++ b/src/createServerClient.spec.ts
@@ -40,6 +40,67 @@ describe("createServerClient", () => {
   describe("use cases", () => {
     const storageKeys = [null, "custom-storage-key"];
 
+    it("should not repeat cache headers across PKCE cookie writes", async () => {
+      const cookieStore = new Map<string, string>();
+      const responseHeaders = new Map<string, string>();
+      let setAllCalls = 0;
+
+      const supabase = createServerClient(
+        "https://project-ref.supabase.co",
+        "anon-key",
+        {
+          cookies: {
+            getAll() {
+              return [...cookieStore].map(([name, value]) => ({ name, value }));
+            },
+
+            setAll(cookiesToSet, headers) {
+              setAllCalls += 1;
+
+              cookiesToSet.forEach(({ name, value }) => {
+                if (value) {
+                  cookieStore.set(name, value);
+                } else {
+                  cookieStore.delete(name);
+                }
+              });
+
+              Object.entries(headers).forEach(([name, value]) => {
+                const normalizedName = name.toLowerCase();
+
+                if (responseHeaders.has(normalizedName)) {
+                  throw new Error(`"${name}" header is already set`);
+                }
+
+                responseHeaders.set(normalizedName, value);
+              });
+            },
+          },
+
+          global: {
+            fetch: async () =>
+              new Response("{}", {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+              }),
+          },
+        },
+      );
+
+      const { error } = await supabase.auth.signInWithOtp({
+        email: "user@example.com",
+      });
+
+      expect(error).toBeNull();
+      expect(setAllCalls).toEqual(3);
+      expect(Object.fromEntries(responseHeaders)).toEqual({
+        "cache-control":
+          "private, no-cache, no-store, must-revalidate, max-age=0",
+        expires: "0",
+        pragma: "no-cache",
+      });
+    });
+
     storageKeys.forEach((storageKey) => {
       it(`should set PKCE code verifier correctly (storage key = ${storageKey})`, async () => {
         let setAllCalls = 0;

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,8 +35,13 @@ export type SetAllCookies = (
    * Headers that must be set on the HTTP response alongside the cookies.
    * Responses that set auth cookies must not be cached by CDNs or
    * reverse proxies, otherwise one user's session token can be served
-   * to a different user. This object is empty after the headers have already
-   * been supplied to an earlier call from the same server client.
+   * to a different user.
+   *
+   * For a server client, the cache headers are delivered only with the first
+   * cookie write. A new server client must be created for each request;
+   * reusing one across requests would leave later responses without the
+   * required cache headers. This object is empty on later calls from the same
+   * client.
    *
    * The library passes the following headers when auth cookies are set:
    * - `Cache-Control: private, no-cache, no-store, must-revalidate, max-age=0`

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,7 +35,8 @@ export type SetAllCookies = (
    * Headers that must be set on the HTTP response alongside the cookies.
    * Responses that set auth cookies must not be cached by CDNs or
    * reverse proxies, otherwise one user's session token can be served
-   * to a different user.
+   * to a different user. This object is empty after the headers have already
+   * been supplied to an earlier call from the same server client.
    *
    * The library passes the following headers when auth cookies are set:
    * - `Cache-Control: private, no-cache, no-store, must-revalidate, max-age=0`


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

Fixes #279.

## What is the current behavior?

Starting an email PKCE flow with `signInWithOtp()` writes the per-flow verifier, flow index, and legacy verifier cookies in separate batches. Each batch currently carries the same cache-prevention headers to `setAll`.

Frameworks that overwrite repeated response headers tolerate this, but SvelteKit's `event.setHeaders()` rejects a second assignment of the same header during one request, causing the auth operation to fail with `"Cache-Control" header is already set`.

## What is the new behavior?

Every cookie batch is still forwarded to `setAll`, while non-empty cache-prevention headers are forwarded only once for the lifetime of a request-scoped server client. The headers are marked as sent only after `setAll` succeeds, so a failed write leaves them available for the next attempt. Later calls after a successful write receive an empty headers object because the response has already been marked as non-cacheable.

The integration regression test exercises the full `createServerClient().auth.signInWithOtp()` path with a strict SvelteKit-style callback. It verifies that all three cookie batches are preserved without assigning any response header twice. A focused unit test verifies that when the first `setAll` call rejects, the next call still receives the cache headers.

## Additional context

The cache headers were introduced in #176 to prevent auth responses from being cached by CDNs. This change preserves that protection because response headers apply to the whole response rather than to an individual cookie batch.

Validation:

- `pnpm exec prettier --check src/cookies.ts src/cookies.spec.ts`
- `pnpm exec eslint`
- `pnpm build`
- `pnpm exec vitest run` (110 tests passed)
- `git diff --check`

AI assistance disclosure: OpenAI Codex assisted with codebase exploration, implementation support, regression-test preparation, code review, and validation. I remain responsible for understanding and maintaining this contribution.