### PR TITLE
fix: warn when auth.storage is ignored by createBrowserClient/createServerClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ Please refer to the [official server-side rendering guides](https://supabase.com
 For guidance on choosing between `getSession()`, `getUser()`, and `getClaims()`,
 see the [official server-side rendering guides](https://supabase.com/docs/guides/auth/server-side).
 
+### The `auth.storage` option is ignored
+
+`createBrowserClient` and `createServerClient` always store the session in
+cookies — this is the entire point of the package, since it lets a
+server-rendered request read the same session the browser wrote. Passing
+`auth.storage` has no effect; a console warning is logged if you do. (`auth.userStorage` is different and is still respected when `cookies.encode` is set to `"tokens-only"`.) If you
+don't need server-side access to the session, use `@supabase/supabase-js`'s
+`createClient` directly with your own `storage` (e.g. `localStorage`) —
+there's no reason to use `@supabase/ssr` in that case.
+
 ### Concurrent requests with the same expired session
 
 Supabase refresh tokens are single-use. If two requests arrive simultaneously

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ see the [official server-side rendering guides](https://supabase.com/docs/guides
 `createBrowserClient` and `createServerClient` always store the session in
 cookies — this is the entire point of the package, since it lets a
 server-rendered request read the same session the browser wrote. Passing
-`auth.storage` has no effect; a console warning is logged if you do. (`auth.userStorage` is different and is still respected when `cookies.encode` is set to `"tokens-only"`.) If you
+`auth.storage` has no effect; a one-time console warning is logged if you do. (`auth.userStorage` is different and is still respected when `cookies.encode` is set to `"tokens-only"`.) If you
 don't need server-side access to the session, use `@supabase/supabase-js`'s
 `createClient` directly with your own `storage` (e.g. `localStorage`) —
 there's no reason to use `@supabase/ssr` in that case.

--- a/src/createBrowserClient.spec.ts
+++ b/src/createBrowserClient.spec.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { MAX_CHUNK_SIZE, stringToBase64URL } from "./utils";
 import { CookieOptions } from "./types";
 import { createBrowserClient } from "./createBrowserClient";
+import { resetWarnOnceForTesting } from "./warnOnce";
 
 // Spy on createClient to capture auth options passed through
 const createClientSpy = vi.fn().mockReturnValue({
@@ -163,6 +164,7 @@ describe("createBrowserClient", () => {
     let warnSpy: any;
 
     beforeEach(() => {
+      resetWarnOnceForTesting();
       warnings = [];
       warnSpy = vi
         .spyOn(console, "warn")
@@ -182,6 +184,21 @@ describe("createBrowserClient", () => {
       });
 
       expect(warnings.some((args) => /auth\.storage/.test(args[0]))).toBe(true);
+    });
+
+    it("warns only once across multiple calls", () => {
+      createBrowserClient("http://localhost", "anon-key", {
+        isSingleton: false,
+        auth: { storage: {} as any },
+      });
+      createBrowserClient("http://localhost", "anon-key", {
+        isSingleton: false,
+        auth: { storage: {} as any },
+      });
+
+      expect(
+        warnings.filter((args) => /auth\.storage/.test(args[0])).length,
+      ).toBe(1);
     });
 
     it("does not warn when `auth.storage` is not passed", () => {

--- a/src/createBrowserClient.spec.ts
+++ b/src/createBrowserClient.spec.ts
@@ -157,4 +157,51 @@ describe("createBrowserClient", () => {
       ).not.toThrow();
     });
   });
+
+  describe("storage option", () => {
+    let warnings: any[][];
+    let warnSpy: any;
+
+    beforeEach(() => {
+      warnings = [];
+      warnSpy = vi
+        .spyOn(console, "warn")
+        .mockImplementation((...args: any[]) => {
+          warnings.push(args);
+        });
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    it("warns when `auth.storage` is passed, since it is always ignored", () => {
+      createBrowserClient("http://localhost", "anon-key", {
+        isSingleton: false,
+        auth: { storage: {} as any },
+      });
+
+      expect(warnings.some((args) => /auth\.storage/.test(args[0]))).toBe(true);
+    });
+
+    it("does not warn when `auth.storage` is not passed", () => {
+      createBrowserClient("http://localhost", "anon-key", {
+        isSingleton: false,
+      });
+
+      expect(warnings.some((args) => /auth\.storage/.test(args[0]))).toBe(
+        false,
+      );
+    });
+
+    it("still uses the cookie-backed storage even when `auth.storage` is passed", () => {
+      createBrowserClient("http://localhost", "anon-key", {
+        isSingleton: false,
+        auth: { storage: { fake: true } as any },
+      });
+
+      const passedOptions = createClientSpy.mock.calls[0][2];
+      expect(passedOptions.auth.storage).not.toEqual({ fake: true });
+    });
+  });
 });

--- a/src/createBrowserClient.ts
+++ b/src/createBrowserClient.ts
@@ -12,6 +12,7 @@ import type {
 } from "./types";
 import { isBrowser } from "./utils";
 import { VERSION } from "./version";
+import { warnOnce } from "./warnOnce";
 import { warnIfUsingDeprecatedAuthHelpersPackage } from "./warnDeprecatedPackage";
 
 let cachedBrowserClient: SupabaseClient<any, any, any> | undefined;
@@ -31,8 +32,8 @@ let cachedBrowserClient: SupabaseClient<any, any, any> | undefined;
  *
  * **The `auth.storage` option is ignored.** The session is always persisted via
  * cookies so that a server-rendered request can read it. Passing
- * `options.auth.storage` has no effect — a console warning is logged if you
- * do. (`options.auth.userStorage` is still respected when `cookies.encode` is `"tokens-only"`.)
+ * `options.auth.storage` has no effect — a one-time console warning is logged
+ * if you do. (`options.auth.userStorage` is still respected when `cookies.encode` is `"tokens-only"`.)
  * If you don't need the session to be readable server-side, use
  * `@supabase/supabase-js`'s `createClient` directly with your own `storage`
  * instead; `@supabase/ssr` isn't needed in that case.
@@ -100,12 +101,6 @@ export function createBrowserClient<
 ): SupabaseClient<Database, SchemaName> {
   warnIfUsingDeprecatedAuthHelpersPackage();
 
-  if (options?.auth?.storage) {
-    console.warn(
-      "@supabase/ssr: createBrowserClient always manages the session via cookies, so the `auth.storage` option you passed is ignored. If you don't need the session to be readable on the server, use @supabase/supabase-js's createClient directly with your own `storage` instead.",
-    );
-  }
-
   // singleton client is created only if isSingleton is set to true, or if isSingleton is not defined and we detect a browser
   const shouldUseSingleton =
     options?.isSingleton === true ||
@@ -118,6 +113,12 @@ export function createBrowserClient<
   if (!supabaseUrl || !supabaseKey) {
     throw new Error(
       `@supabase/ssr: Your project's URL and API key are required to create a Supabase client!\n\nCheck your Supabase project's API settings to find these values\n\nhttps://supabase.com/dashboard/project/_/settings/api`,
+    );
+  }
+
+  if (options?.auth?.storage) {
+    warnOnce(
+      "@supabase/ssr: createBrowserClient always manages the session via cookies, so the `auth.storage` option you passed is ignored. If you don't need the session to be readable on the server, use @supabase/supabase-js's createClient directly with your own `storage` instead.",
     );
   }
 

--- a/src/createBrowserClient.ts
+++ b/src/createBrowserClient.ts
@@ -29,6 +29,14 @@ let cachedBrowserClient: SupabaseClient<any, any, any> | undefined;
  * in difficult to debug authentication issues such as random logouts, early
  * session termination or problems with inconsistent state.
  *
+ * **The `auth.storage` option is ignored.** The session is always persisted via
+ * cookies so that a server-rendered request can read it. Passing
+ * `options.auth.storage` has no effect — a console warning is logged if you
+ * do. (`options.auth.userStorage` is still respected when `cookies.encode` is `"tokens-only"`.)
+ * If you don't need the session to be readable server-side, use
+ * `@supabase/supabase-js`'s `createClient` directly with your own `storage`
+ * instead; `@supabase/ssr` isn't needed in that case.
+ *
  * @param supabaseUrl The URL of the Supabase project.
  * @param supabaseKey The `anon` API key of the Supabase project.
  * @param options Various configuration options.
@@ -91,6 +99,12 @@ export function createBrowserClient<
   },
 ): SupabaseClient<Database, SchemaName> {
   warnIfUsingDeprecatedAuthHelpersPackage();
+
+  if (options?.auth?.storage) {
+    console.warn(
+      "@supabase/ssr: createBrowserClient always manages the session via cookies, so the `auth.storage` option you passed is ignored. If you don't need the session to be readable on the server, use @supabase/supabase-js's createClient directly with your own `storage` instead.",
+    );
+  }
 
   // singleton client is created only if isSingleton is set to true, or if isSingleton is not defined and we detect a browser
   const shouldUseSingleton =

--- a/src/createServerClient.spec.ts
+++ b/src/createServerClient.spec.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { MAX_CHUNK_SIZE, stringToBase64URL } from "./utils";
 import { CookieOptions } from "./types";
 import { createServerClient } from "./createServerClient";
+import { resetWarnOnceForTesting } from "./warnOnce";
 
 describe("createServerClient", () => {
   describe("validation", () => {
@@ -632,6 +633,7 @@ describe("createServerClient", () => {
     let warnSpy: any;
 
     beforeEach(() => {
+      resetWarnOnceForTesting();
       warnings = [];
       warnSpy = vi
         .spyOn(console, "warn")
@@ -660,6 +662,35 @@ describe("createServerClient", () => {
       expect(warnings.some((args) => /auth\.storage/.test(args[0]))).toBe(true);
     });
 
+    it("warns only once across multiple calls", () => {
+      const options = {
+        cookies: {
+          getAll() {
+            return [];
+          },
+          setAll() {
+            // no-op
+          },
+        },
+        auth: { storage: {} as any },
+      };
+
+      createServerClient(
+        "https://project-ref.supabase.co",
+        "anon-key",
+        options,
+      );
+      createServerClient(
+        "https://project-ref.supabase.co",
+        "anon-key",
+        options,
+      );
+
+      expect(
+        warnings.filter((args) => /auth\.storage/.test(args[0])).length,
+      ).toBe(1);
+    });
+
     it("does not warn when `auth.storage` is not passed", () => {
       createServerClient("https://project-ref.supabase.co", "anon-key", {
         cookies: {
@@ -675,6 +706,75 @@ describe("createServerClient", () => {
       expect(warnings.some((args) => /auth\.storage/.test(args[0]))).toBe(
         false,
       );
+    });
+
+    it("still uses the cookie-backed storage even when `auth.storage` is passed", async () => {
+      const customStorageCalls: string[] = [];
+
+      const supabase = createServerClient(
+        "https://project-ref.supabase.co",
+        "anon-key",
+        {
+          cookies: {
+            getAll() {
+              return [
+                {
+                  name: "sb-project-ref-auth-token",
+                  value:
+                    "base64-" +
+                    stringToBase64URL(
+                      JSON.stringify({
+                        token_type: "bearer",
+                        access_token: "<valid-access-token>",
+                        refresh_token: "<valid-refresh-token>",
+                        expires_at: Math.floor(Date.now() / 1000) + 5 * 60, // expires in 5 mins
+                        expires_in: 5 * 60,
+                        user: {
+                          id: "<valid-user-id>",
+                        },
+                      }),
+                    ),
+                },
+              ];
+            },
+
+            setAll() {
+              // no-op
+            },
+          },
+
+          auth: {
+            storage: {
+              getItem: async (key: string) => {
+                customStorageCalls.push(key);
+                return null;
+              },
+              setItem: async (key: string) => {
+                customStorageCalls.push(key);
+              },
+              removeItem: async (key: string) => {
+                customStorageCalls.push(key);
+              },
+            },
+          },
+
+          global: {
+            fetch: async () => {
+              throw new Error("Should not be called");
+            },
+          },
+        },
+      );
+
+      const {
+        data: { session },
+        error,
+      } = await supabase.auth.getSession();
+
+      expect(error).toBeNull();
+      expect(session).not.toBeNull();
+      expect(session!.user.id).toEqual("<valid-user-id>");
+      expect(customStorageCalls).toEqual([]);
     });
   });
 });

--- a/src/createServerClient.spec.ts
+++ b/src/createServerClient.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 import { MAX_CHUNK_SIZE, stringToBase64URL } from "./utils";
 import { CookieOptions } from "./types";
@@ -624,6 +624,57 @@ describe("createServerClient", () => {
 
       // Constructor must not trigger any network activity
       expect(fetchCallCount).toBe(0);
+    });
+  });
+
+  describe("storage option", () => {
+    let warnings: any[][];
+    let warnSpy: any;
+
+    beforeEach(() => {
+      warnings = [];
+      warnSpy = vi
+        .spyOn(console, "warn")
+        .mockImplementation((...args: any[]) => {
+          warnings.push(args);
+        });
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    it("warns when `auth.storage` is passed, since it is always ignored", () => {
+      createServerClient("https://project-ref.supabase.co", "anon-key", {
+        cookies: {
+          getAll() {
+            return [];
+          },
+          setAll() {
+            // no-op
+          },
+        },
+        auth: { storage: {} as any },
+      });
+
+      expect(warnings.some((args) => /auth\.storage/.test(args[0]))).toBe(true);
+    });
+
+    it("does not warn when `auth.storage` is not passed", () => {
+      createServerClient("https://project-ref.supabase.co", "anon-key", {
+        cookies: {
+          getAll() {
+            return [];
+          },
+          setAll() {
+            // no-op
+          },
+        },
+      });
+
+      expect(warnings.some((args) => /auth\.storage/.test(args[0]))).toBe(
+        false,
+      );
     });
   });
 });

--- a/src/createServerClient.ts
+++ b/src/createServerClient.ts
@@ -84,6 +84,13 @@ export function createServerClient<
  * no explicit JWT is passed). Token refreshes write the updated session back
  * to cookies via the `setAll` handler.
  *
+ * **The `auth.storage` option is ignored.** The session is always persisted via
+ * cookies. Passing `options.auth.storage` has no effect — a console warning
+ * is logged if you do. (`options.auth.userStorage` is still respected when `cookies.encode` is `"tokens-only"`.)
+ * If you want to source the session from somewhere other than the request cookies,
+ * use `@supabase/supabase-js`'s `createClient` directly with your own `storage`
+ * instead; `@supabase/ssr` isn't needed in that case.
+ *
  * @param supabaseUrl The URL of the Supabase project.
  * @param supabaseKey The `anon` API key of the Supabase project.
  * @param options Various configuration options.
@@ -122,6 +129,12 @@ export function createServerClient<
   },
 ): SupabaseClient<Database, SchemaName> {
   warnIfUsingDeprecatedAuthHelpersPackage();
+
+  if (options?.auth?.storage) {
+    console.warn(
+      "@supabase/ssr: createServerClient always manages the session via cookies, so the `auth.storage` option you passed is ignored. If you want to source the session from somewhere other than the request cookies, use @supabase/supabase-js's createClient directly with your own `storage` instead.",
+    );
+  }
 
   if (!supabaseUrl || !supabaseKey) {
     throw new Error(

--- a/src/createServerClient.ts
+++ b/src/createServerClient.ts
@@ -13,6 +13,7 @@ import type {
 } from "./types";
 import { memoryLocalStorageAdapter } from "./utils/helpers";
 import { VERSION } from "./version";
+import { warnOnce } from "./warnOnce";
 import { warnIfUsingDeprecatedAuthHelpersPackage } from "./warnDeprecatedPackage";
 
 /**
@@ -85,8 +86,8 @@ export function createServerClient<
  * to cookies via the `setAll` handler.
  *
  * **The `auth.storage` option is ignored.** The session is always persisted via
- * cookies. Passing `options.auth.storage` has no effect — a console warning
- * is logged if you do. (`options.auth.userStorage` is still respected when `cookies.encode` is `"tokens-only"`.)
+ * cookies. Passing `options.auth.storage` has no effect — a one-time console
+ * warning is logged if you do. (`options.auth.userStorage` is still respected when `cookies.encode` is `"tokens-only"`.)
  * If you want to source the session from somewhere other than the request cookies,
  * use `@supabase/supabase-js`'s `createClient` directly with your own `storage`
  * instead; `@supabase/ssr` isn't needed in that case.
@@ -130,15 +131,15 @@ export function createServerClient<
 ): SupabaseClient<Database, SchemaName> {
   warnIfUsingDeprecatedAuthHelpersPackage();
 
-  if (options?.auth?.storage) {
-    console.warn(
-      "@supabase/ssr: createServerClient always manages the session via cookies, so the `auth.storage` option you passed is ignored. If you want to source the session from somewhere other than the request cookies, use @supabase/supabase-js's createClient directly with your own `storage` instead.",
-    );
-  }
-
   if (!supabaseUrl || !supabaseKey) {
     throw new Error(
       `Your project's URL and Key are required to create a Supabase client!\n\nCheck your Supabase project's API settings to find these values\n\nhttps://supabase.com/dashboard/project/_/settings/api`,
+    );
+  }
+
+  if (options?.auth?.storage) {
+    warnOnce(
+      "@supabase/ssr: createServerClient always manages the session via cookies, so the `auth.storage` option you passed is ignored. If you want to source the session from somewhere other than the request cookies, use @supabase/supabase-js's createClient directly with your own `storage` instead.",
     );
   }
 

--- a/src/warnOnce.ts
+++ b/src/warnOnce.ts
@@ -1,0 +1,22 @@
+const warnedMessages = new Set<string>();
+
+/**
+ * Logs a warning to the console only once per process for each distinct
+ * message. Used for configuration warnings that would otherwise fire on
+ * every client creation (e.g. once per server request).
+ */
+export function warnOnce(message: string): void {
+  if (warnedMessages.has(message)) {
+    return;
+  }
+
+  warnedMessages.add(message);
+  console.warn(message);
+}
+
+/**
+ * Clears the set of already-logged messages. Only for use in tests.
+ */
+export function resetWarnOnceForTesting(): void {
+  warnedMessages.clear();
+}


### PR DESCRIPTION
`createBrowserClient` and `createServerClient` always store the session via cookies, so any `auth.storage` you pass in is silently overwritten and has no effect. This adds a one-time console warning when that option is passed, plus a short doc note (in both functions' tsdoc and the README) clarifying that `auth.storage` is ignored, while `auth.userStorage` remains respected when `cookies.encode` is `"tokens-only"`.

The warning is deduped via a small `warnOnce` helper (kept out of the public API), so apps that create a server client per request log it once per process instead of on every request. The check also runs after the singleton short-circuit and URL/key validation, so a cached no-op `createBrowserClient` call or a call that's about to throw doesn't warn. Tests cover the warning firing, firing only once across multiple calls, and (behaviorally, on the server client) that the cookie-backed storage still wins over a custom `auth.storage`.

No behavior change: the cookie-backed storage still always wins, this only makes the existing no-op visible instead of silent.

Fixes #142
