### PR TITLE
chore: import cookie as a namespace for consistency with helpers

### DIFF
--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -1,4 +1,4 @@
-import { parse, serialize } from "cookie";
+import * as cookie from "cookie";
 
 import {
   DEFAULT_COOKIE_OPTIONS,
@@ -121,7 +121,7 @@ export function createStorageFromOptions(
   let setAll: SetAllCookies;
 
   const documentCookieGetAll = () => {
-    const parsed = parse(document.cookie);
+    const parsed = cookie.parse(document.cookie);
 
     return Object.keys(parsed).map((name) => ({
       name,
@@ -131,7 +131,7 @@ export function createStorageFromOptions(
 
   const documentCookieSetAll: SetAllCookies = (setCookies) => {
     setCookies.forEach(({ name, value, options }) => {
-      document.cookie = serialize(name, value, options);
+      document.cookie = cookie.serialize(name, value, options);
     });
   };
 


### PR DESCRIPTION
**Scope correction: this is a consistency cleanup, not a fix for the linked issues.** (Original body wrongly claimed it fixes them; corrected after building a reproduction.)

`helpers.ts` switched to `import * as cookie` in 64ff6b3; `cookies.ts` is the last named runtime import from `cookie` in `src/`. This aligns the two files.

Why this does not resolve #62 / #102 / #137: reproduced those against `@supabase/ssr@0.12.5` (Vite 7 + pnpm, `optimizeDeps.exclude` to match the raw `.pnpm/...?v=<hash>` URLs in the reports). `cookie` ships CJS-only (`main` only, no `exports` map, no ESM build), and a raw CJS file cannot run as a browser ES module under any import style. With this patch applied the failure only changes shape:

```
named import:      SyntaxError: does not provide an export named 'parse'
namespace import:  ReferenceError: exports is not defined
```

In the same setup, aliasing `cookie` to `cookie-es` (ESM-native) resolves the error with the current named imports untouched, which points at the real fix being a dependency swap or bundling `cookie` into dist. Happy to open that PR if that direction works for you; root-cause analysis posted in #62.

116/116 unit tests pass; no behavior change.

Disclosure: prepared with Claude assistance; the reproduction and verification above were run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
