### PR TITLE
fix: apply non-browser defaults when cookies only sets encode

### DIFF
--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -111,7 +111,12 @@ export function createStorageFromOptions(
   },
   isServerClient: boolean,
 ) {
-  const cookies = options.cookies ?? null;
+  // A cookies object without accessors (e.g. only `encode`) is treated the
+  // same as omitting cookies, so the runtime-specific defaults below apply.
+  const cookies =
+    options.cookies && ("get" in options.cookies || "getAll" in options.cookies)
+      ? options.cookies
+      : null;
   const cookieEncoding = options.cookieEncoding;
 
   const setItems: { [key: string]: string } = {};
@@ -210,12 +215,6 @@ export function createStorageFromOptions(
           "@supabase/ssr: createBrowserClient requires configuring both getAll and setAll cookie methods (deprecated: alternatively both get, set and remove can be used)",
         );
       }
-    } else if (!isServerClient && isBrowser()) {
-      // cookies object provided (e.g. just to set `encode`) but no accessors.
-      // Fall through to document.cookie defaults, same as when cookies isn't
-      // provided at all.
-      getAll = () => documentCookieGetAll();
-      setAll = documentCookieSetAll;
     } else {
       // neither get nor getAll is present on cookies, only will occur if pure JavaScript is used, but cookies is an object
       throw new Error(

--- a/src/createBrowserClient.spec.ts
+++ b/src/createBrowserClient.spec.ts
@@ -159,6 +159,39 @@ describe("createBrowserClient", () => {
     });
   });
 
+  describe("encode option outside a browser runtime", () => {
+    it("accepts cookies: { encode: 'tokens-only' } without getAll/setAll when window is undefined", async () => {
+      expect(() =>
+        createBrowserClient("http://localhost", "anon-key", {
+          isSingleton: false,
+          cookies: { encode: "tokens-only" },
+        }),
+      ).not.toThrow();
+
+      const passedOptions = createClientSpy.mock.calls[0][2];
+      expect(passedOptions.auth.userStorage).toBeDefined();
+      expect(
+        await passedOptions.auth.storage.getItem("sb-x-auth-token"),
+      ).toBeNull();
+    });
+
+    it("accepts cookies: { encode: 'tokens-only' } with getAll/setAll when window is undefined", () => {
+      expect(() =>
+        createBrowserClient("http://localhost", "anon-key", {
+          isSingleton: false,
+          cookies: {
+            encode: "tokens-only",
+            getAll: () => [],
+            setAll: () => {},
+          },
+        }),
+      ).not.toThrow();
+
+      const passedOptions = createClientSpy.mock.calls[0][2];
+      expect(passedOptions.auth.userStorage).toBeDefined();
+    });
+  });
+
   describe("storage option", () => {
     let warnings: any[][];
     let warnSpy: any;

--- a/src/createBrowserClient.ts
+++ b/src/createBrowserClient.ts
@@ -10,7 +10,7 @@ import type {
   CookieMethodsBrowserDeprecated,
   CookieOptionsWithName,
 } from "./types";
-import { isBrowser } from "./utils";
+import { isBrowser, memoryLocalStorageAdapter } from "./utils";
 import { VERSION } from "./version";
 import { warnOnce } from "./warnOnce";
 import { warnIfUsingDeprecatedAuthHelpersPackage } from "./warnDeprecatedPackage";
@@ -154,7 +154,9 @@ export function createBrowserClient<
       "encode" in options.cookies &&
       options.cookies.encode === "tokens-only"
         ? {
-            userStorage: options?.auth?.userStorage ?? window.localStorage,
+            userStorage:
+              options?.auth?.userStorage ??
+              (isBrowser() ? window.localStorage : memoryLocalStorageAdapter()),
           }
         : null),
     },


### PR DESCRIPTION
Fixes #293.

`createBrowserClient` with `cookies: { encode: "tokens-only" }` and no accessors throws outside a browser runtime (for example Next.js pre-rendering), while omitting `cookies` entirely works there. #213 added the encode-only fallback but only mirrored the `document.cookie` branch, so the non-browser branch was skipped:

- `cookies: { encode: "tokens-only" }` -> `createBrowserClient requires configuring getAll and setAll cookie methods`
- the same plus `getAll`/`setAll` -> `ReferenceError: window is not defined` (from `userStorage: window.localStorage`)

A cookies object without `get`/`getAll` is now treated the same as omitting `cookies`, so every runtime goes through the existing defaults (`document.cookie` in browsers, the empty `getAll` plus lazy-throwing `setAll` elsewhere), and the encode-only branch from #213 is no longer needed. `userStorage` falls back to `memoryLocalStorageAdapter()` outside a browser, matching `createServerClient`.

Tests: two cases in `createBrowserClient.spec.ts` run without a `window` stub; both fail on main and pass here. Full suite 120/120, `prettier --check`, `eslint` and both tsc builds clean.
